### PR TITLE
ci: validate pull request titles as conventional commits

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,60 @@
+name: pr-title
+
+# This repository squash merges with `squash_merge_commit_title: PR_TITLE`, so the
+# pull request title becomes the subject of the commit that lands on main. release-please
+# then parses that subject to decide the next version and to build the CHANGELOG.
+# A malformed title is therefore not a cosmetic problem: a missing `!` ships a breaking
+# change as a patch, and an unrecognised type silently drops the entry from the CHANGELOG.
+on:
+  pull_request:
+    # `edited` catches a title fixed after the pull request was opened. `synchronize` is
+    # needed so that a run exists for every head commit; without it, making this a required
+    # check would block any pull request that received a push after the last title change.
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+# Deny by default; the job below requests only the scope it needs.
+permissions: {}
+
+concurrency:
+  group: pr-title-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Listed explicitly rather than relying on the action's defaults, so that the
+          # accepted vocabulary is reviewable here and cannot drift with an upstream bump.
+          # release-please maps `feat` to a minor bump and `fix` to a patch; the remaining
+          # types are hidden from the CHANGELOG but still allowed as commit subjects.
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          # Dependabot titles its pull requests `build(deps): ...`, so a scope has to stay
+          # permitted, but nothing in this project requires one.
+          requireScope: false
+          # Keep CHANGELOG entries uniform: every existing entry starts lowercase.
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}" should start
+            with a lowercase character, so that it reads consistently with the other
+            entries in CHANGELOG.md.

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -54,7 +54,9 @@ jobs:
           requireScope: false
           # Keep CHANGELOG entries uniform: every existing entry starts lowercase.
           subjectPattern: ^(?![A-Z]).+$
-          subjectPatternError: |
+          # Folded, not literal: GitHub truncates an `::error::` annotation at the first
+          # newline, which would hide everything after "should start".
+          subjectPatternError: >-
             The subject "{subject}" found in the pull request title "{title}" should start
             with a lowercase character, so that it reads consistently with the other
             entries in CHANGELOG.md.


### PR DESCRIPTION
release-please derives the next version and the CHANGELOG from the subject of each commit on `main`. This repository squash merges with `squash_merge_commit_title: PR_TITLE`, so that subject is the pull request title. A malformed title is therefore not cosmetic: a missing `!` ships a breaking change as a patch release, and an unrecognised type drops the entry from the CHANGELOG. A `doc: add installation to README.md` title already slipped through once with a type release-please cannot map.

Adds a workflow that checks the title against the conventional commits spec.

- The accepted types are listed explicitly rather than inherited from the action defaults, so the vocabulary is reviewable in the repository and cannot drift with an upstream bump.
- `requireScope` stays false. Dependabot titles its pull requests `build(deps): ...`, so a scope has to remain permitted, but nothing in this project requires one.
- `subjectPattern` rejects a subject that starts with an uppercase character, keeping CHANGELOG entries uniform with the existing ones.

Kept as its own workflow rather than a job in `ci.yml`, because it needs the `edited` trigger and that would otherwise re-run lint and tests on every title or description edit. `synchronize` is included so that a run exists for every head commit, which is a prerequisite for making this a required check.

Checked against all 34 existing pull request titles in this repository: 33 pass, and the only failure is the `doc:` typo above. The open release-please pull request (`chore: release 0.3.1`) and the Dependabot pull requests pass.
