### PR TITLE
feat!: replace requests exceptions with a pyreinfolib exception hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,49 @@ from pyreinfolib.enums import UseDivision
 client.get_appraisal_reports(year=2024, area="13", division=UseDivision.INDUSTRIAL_LAND)
 ```
 
+## Error handling
+
+このライブラリが送出する例外はすべて `ReinfolibError` を継承しています。`requests` を import せずに捕捉できます。
+
+```
+ReinfolibError
+├── TransportError          レスポンスを得られなかった（接続失敗・タイムアウト）
+└── APIError                レスポンスは返ったが利用できない（status_code / response_body / url を持つ）
+    ├── AuthenticationError APIキーが未指定または拒否された（401）
+    ├── NoResultsError      検索結果が0件（404）
+    ├── RateLimitError      同一APIキーからのリクエストが多すぎる（429）
+    └── InvalidResponseError レスポンスがJSONではなかった
+```
+
+### 検索結果が0件のとき
+
+タイル座標を取らない3つのAPI（`get_real_estate_prices`、`get_municipalities`、`get_appraisal_reports`）は、条件に合致するデータが無い場合に空の結果ではなく **HTTP 404** を返します（[API操作説明](https://www.reinfolib.mlit.go.jp/help/apiManual/)の3章 Q.8）。このライブラリではこれを `NoResultsError` として送出します。
+
+```python
+from pyreinfolib import Client, NoResultsError
+
+client = Client(api_key=...)
+try:
+    prices = client.get_real_estate_prices(year=2024, city="13109")
+except NoResultsError:
+    prices = {"data": []}
+```
+
+タイル座標を取るAPIは0件でも200と空のフィーチャ一覧を返すため、`NoResultsError` は発生しません。
+
+### 失敗の詳細を見る
+
+`APIError` とそのサブクラスは、APIが返した本文を保持しています。
+
+```python
+from pyreinfolib import APIError
+
+try:
+    client.get_municipalities(area="99")
+except APIError as e:
+    print(e.status_code, e.response_body, e.url)
+```
+
 ## Typing
 
 型情報を同梱しています（[PEP 561](https://peps.python.org/pep-0561/)）。

--- a/pyreinfolib/__init__.py
+++ b/pyreinfolib/__init__.py
@@ -1,5 +1,23 @@
 from .client import Client
+from .exceptions import (
+    APIError,
+    AuthenticationError,
+    InvalidResponseError,
+    NoResultsError,
+    RateLimitError,
+    ReinfolibError,
+    TransportError,
+)
 
-__all__ = ["Client"]
+__all__ = [
+    "APIError",
+    "AuthenticationError",
+    "Client",
+    "InvalidResponseError",
+    "NoResultsError",
+    "RateLimitError",
+    "ReinfolibError",
+    "TransportError",
+]
 
 __version__ = "0.3.0"

--- a/pyreinfolib/client.py
+++ b/pyreinfolib/client.py
@@ -1,15 +1,25 @@
-import logging
 from collections.abc import Sequence
 from typing import Any, Literal
 from urllib.parse import urljoin
 
 import requests
 
-from pyreinfolib import enums
-
-logger = logging.getLogger(__name__)
+from pyreinfolib import enums, exceptions
 
 DEFAULT_TIMEOUT = 30.0
+
+# Statuses whose meaning the API documents. Anything else falls back to `APIError`, which
+# still carries the body, so the caller can read the API's own explanation.
+#
+# 403 is deliberately absent. The API manual does not mention it, and the gateway in front
+# of this API uses 401 for a missing or invalid subscription key while reserving 403 for an
+# exhausted call quota. Calling it an authentication failure would send the caller off to
+# check a key that is fine.
+_STATUS_TO_EXCEPTION: dict[int, type[exceptions.APIError]] = {
+    401: exceptions.AuthenticationError,
+    404: exceptions.NoResultsError,
+    429: exceptions.RateLimitError,
+}
 
 
 def _join_codes(codes: Sequence[str] | str) -> str:
@@ -42,16 +52,45 @@ class Client:
         self.timeout = timeout
 
     def _get(self, endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Issue a GET against `endpoint` and return the decoded JSON body.
+
+        :raises TransportError: If no response was obtained.
+        :raises AuthenticationError: If the API key was missing or rejected.
+        :raises NoResultsError: If the query matched no data.
+        :raises RateLimitError: If the API key sent too many requests.
+        :raises InvalidResponseError: If the body was not valid JSON.
+        :raises APIError: For any other error status.
+        """
         api_url = urljoin(self.base_url, endpoint)
         headers = {"Ocp-Apim-Subscription-Key": self.api_key}
+
+        # Each failure mode gets its own `try`. Wrapping the whole exchange in one block
+        # would have to re-derive which stage failed from the exception type, which is how
+        # the previous version came to dereference a `response` that connection errors and
+        # timeouts do not have.
         try:
             r = requests.get(api_url, headers=headers, params=params, timeout=self.timeout)
-            r.raise_for_status()
-            return r.json()
         except requests.RequestException as e:
-            detail = e.response.text if e.response is not None else str(e)
-            logger.error("Request failed for %s with error: %s", api_url, detail)
-            raise
+            raise exceptions.TransportError(f"Request to {api_url} failed: {e}") from e
+
+        if not r.ok:
+            error = _STATUS_TO_EXCEPTION.get(r.status_code, exceptions.APIError)
+            raise error(
+                f"{r.status_code} {r.reason} for {r.url}: {r.text}",
+                status_code=r.status_code,
+                response_body=r.text,
+                url=r.url,
+            )
+
+        try:
+            return r.json()
+        except requests.exceptions.JSONDecodeError as e:
+            raise exceptions.InvalidResponseError(
+                f"Response from {r.url} was not valid JSON: {e}",
+                status_code=r.status_code,
+                response_body=r.text,
+                url=r.url,
+            ) from e
 
     def get_real_estate_prices(
         self,
@@ -74,6 +113,7 @@ class Client:
         :param station: Station code. See https://nlftp.mlit.go.jp/ksj/gml/datalist/KsjTmplt-N02-v3_1.html
         :param language: `ja` or `en`. If not specified, `ja`.
         :return: Real estate prices.
+        :raises NoResultsError: If no transaction matches the given period and area.
         """
         params: dict[str, Any] = {"year": year}
         if price_classification:
@@ -97,6 +137,7 @@ class Client:
         :param area: Prefecture code. See https://nlftp.mlit.go.jp/ksj/gml/codelist/PrefCd.html
         :param language: `ja` or `en`. If not specified, `ja`.
         :return: Municipality list.
+        :raises NoResultsError: If the prefecture code matches no municipality.
         """
         params: dict[str, Any] = {"area": area}
         if language:
@@ -111,6 +152,7 @@ class Client:
         :param area: Prefecture code.
         :param division: Use division.
         :return: Real estate appraisal reports.
+        :raises NoResultsError: If no appraisal report matches the given year and area.
         """
         params: dict[str, Any] = {"year": year, "area": area, "division": division}
 

--- a/pyreinfolib/exceptions.py
+++ b/pyreinfolib/exceptions.py
@@ -1,0 +1,70 @@
+"""Exceptions raised by pyreinfolib.
+
+Every error raised by this library derives from `ReinfolibError`, so a caller can guard
+a call site without importing `requests`. That keeps the transport an implementation
+detail: swapping it out later does not change the exceptions callers catch.
+
+This module deliberately imports nothing from `requests`. Translating a response into
+one of these exceptions is the client's job, in `pyreinfolib.client`.
+"""
+
+
+class ReinfolibError(Exception):
+    """Base class for every error raised by this library."""
+
+
+class TransportError(ReinfolibError):
+    """No response was obtained from the API.
+
+    Raised for connection failures, DNS errors and timeouts. There is no status code to
+    inspect; the underlying transport exception is kept as `__cause__`.
+    """
+
+
+class APIError(ReinfolibError):
+    """The API responded, but the response could not be used.
+
+    :ivar status_code: HTTP status code of the response.
+    :ivar response_body: Raw response body. The API explains itself here, usually as
+      `{"message": ...}`.
+    :ivar url: The requested URL. The API key travels in a header, not the query string,
+      so this is safe to log.
+    """
+
+    def __init__(self, message: str, *, status_code: int, response_body: str, url: str) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
+        self.url = url
+
+
+class AuthenticationError(APIError):
+    """The API key was missing or rejected (HTTP 401)."""
+
+
+class NoResultsError(APIError):
+    """The query matched no data (HTTP 404).
+
+    This is a normal outcome, not a fault. The three endpoints that do not take tile
+    coordinates -- XIT001, XIT002 and XCT001 -- answer 404 instead of returning an empty
+    result set. Endpoints that do take tile coordinates answer 200 with an empty feature
+    list, and so never raise this.
+
+    See section 3, Q.8 of https://www.reinfolib.mlit.go.jp/help/apiManual/
+    """
+
+
+class RateLimitError(APIError):
+    """The API key sent too many requests in too short a period (HTTP 429).
+
+    The API publishes no explicit request ceiling; it asks that calls be spaced out.
+    See section 3, Q.3 of https://www.reinfolib.mlit.go.jp/help/apiManual/
+    """
+
+
+class InvalidResponseError(APIError):
+    """The response body was not the JSON the API is documented to return.
+
+    A maintenance page served with HTTP 200 lands here, which is why this carries a
+    status code like the other `APIError` subclasses.
+    """

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,3 @@
-import logging
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -9,6 +8,15 @@ import responses
 
 from pyreinfolib import Client
 from pyreinfolib.enums import LandTypeCode, UseDivision
+from pyreinfolib.exceptions import (
+    APIError,
+    AuthenticationError,
+    InvalidResponseError,
+    NoResultsError,
+    RateLimitError,
+    ReinfolibError,
+    TransportError,
+)
 
 BASE_URL = "https://www.reinfolib.mlit.go.jp/ex-api/external/"
 API_KEY = "dummy"
@@ -106,27 +114,51 @@ class TestClient:
         expected = DEFAULT_TIMEOUT if timeout is None else timeout
         assert mock_api.calls[0].request.req_kwargs["timeout"] == expected
 
-    @pytest.mark.parametrize("status", [400, 404, 500])
-    def test__get_raises_on_error_status(self, mock_api, client, status):
-        mock_api.get(f"{BASE_URL}TEST999", json={"message": "検索結果がありません。"}, status=status)
+    @pytest.mark.parametrize(
+        ("status", "expected"),
+        [
+            (400, APIError),
+            (401, AuthenticationError),
+            # Not AuthenticationError: the gateway uses 403 for an exhausted call quota,
+            # and the API manual documents no meaning for it either way.
+            (403, APIError),
+            (404, NoResultsError),
+            (429, RateLimitError),
+            (500, APIError),
+            (503, APIError),
+        ],
+    )
+    def test__get_maps_error_status_to_a_specific_exception(self, mock_api, client, status, expected):
+        mock_api.get(f"{BASE_URL}TEST999", json={"message": "error"}, status=status)
 
-        with pytest.raises(requests.RequestException):
+        with pytest.raises(expected) as exc_info:
             client._get("TEST999", {"param1": "value1"})
 
-    def test__get_logs_response_body_on_error_status(self, mock_api, client, caplog):
-        # Registered as a raw body rather than `json=`, which would escape the non-ASCII
-        # characters and no longer match what the API actually returns.
+        # `pytest.raises(expected)` would also accept a subclass, so pin the exact type:
+        # mapping 500 onto `NoResultsError`, say, would otherwise pass as an `APIError`.
+        assert type(exc_info.value) is expected
+        assert exc_info.value.status_code == status
+
+    def test__get_error_carries_the_response_body(self, mock_api, client):
+        """The API explains itself in the body; discarding it leaves nothing to debug.
+
+        Registered as a raw body rather than `json=`, which would escape the non-ASCII
+        characters and no longer match what the API actually returns.
+        """
         mock_api.get(
             f"{BASE_URL}TEST999",
             body='{"message":"検索結果がありません。"}',
             content_type="application/json",
-            status=400,
+            status=404,
         )
 
-        with caplog.at_level(logging.ERROR, logger="pyreinfolib.client"), pytest.raises(requests.RequestException):
+        with pytest.raises(NoResultsError) as exc_info:
             client._get("TEST999")
 
-        assert "検索結果がありません。" in caplog.text
+        error = exc_info.value
+        assert error.response_body == '{"message":"検索結果がありません。"}'
+        assert error.url == f"{BASE_URL}TEST999"
+        assert "検索結果がありません。" in str(error)
 
     @pytest.mark.parametrize(
         "raised",
@@ -136,29 +168,40 @@ class TestClient:
         ],
         ids=lambda exc: type(exc).__name__,
     )
-    def test__get_propagates_errors_that_carry_no_response(self, mock_api, client, caplog, raised):
-        """`e.response` is None here, so the handler must not dereference it.
+    def test__get_wraps_failures_that_carry_no_response(self, mock_api, client, raised):
+        """These never produced a response, so they cannot become an `APIError`.
 
-        Dereferencing it replaced the real cause with `AttributeError: 'NoneType' object
-        has no attribute 'text'`, which is exactly the case one needs to debug.
+        An earlier version dereferenced `e.response.text` unconditionally and replaced the
+        real cause with `AttributeError: 'NoneType' object has no attribute 'text'`, which
+        is exactly the case one needs to debug.
         """
         mock_api.get(f"{BASE_URL}TEST001", body=raised)
 
-        with caplog.at_level(logging.ERROR, logger="pyreinfolib.client"), pytest.raises(type(raised)) as exc_info:
+        with pytest.raises(TransportError) as exc_info:
             client._get("TEST001")
 
-        assert exc_info.value.response is None
-        assert str(raised) in caplog.text
+        # The original exception stays reachable for anyone who needs the transport detail.
+        assert exc_info.value.__cause__ is raised
+        assert str(raised) in str(exc_info.value)
 
-    def test__get_propagates_json_decode_error(self, mock_api, client, caplog):
-        """A 200 response with a non-JSON body (a maintenance page, say) also has no `response`."""
+    def test__get_rejects_a_success_response_that_is_not_json(self, mock_api, client):
+        """A maintenance page served with HTTP 200 must not surface as a `requests` error."""
         mock_api.get(f"{BASE_URL}TEST001", body="<html>maintenance</html>", content_type="text/html")
 
-        with caplog.at_level(logging.ERROR, logger="pyreinfolib.client"):
-            with pytest.raises(requests.exceptions.JSONDecodeError):
-                client._get("TEST001")
+        with pytest.raises(InvalidResponseError) as exc_info:
+            client._get("TEST001")
 
-        assert f"Request failed for {BASE_URL}TEST001" in caplog.text
+        error = exc_info.value
+        assert error.status_code == 200
+        assert error.response_body == "<html>maintenance</html>"
+
+    @pytest.mark.parametrize("status", [404, 500])
+    def test__get_does_not_leak_requests_exceptions(self, mock_api, client, status):
+        """Catching `ReinfolibError` alone must be enough, with no import of `requests`."""
+        mock_api.get(f"{BASE_URL}TEST999", json={"message": "error"}, status=status)
+
+        with pytest.raises(ReinfolibError):
+            client._get("TEST999")
 
     @pytest.mark.parametrize(
         "case",
@@ -388,3 +431,28 @@ class TestClient:
     )
     def test_get_number_of_passengers_per_station(self, mock_api, client, case):
         assert_request(mock_api, client.get_number_of_passengers_per_station, "XKT015", case)
+
+
+class TestExceptions:
+    """The shape of the hierarchy is public API: callers catch these instead of `requests`."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [APIError, AuthenticationError, InvalidResponseError, NoResultsError, RateLimitError, TransportError],
+        ids=lambda exc: exc.__name__,
+    )
+    def test_every_exception_derives_from_reinfolib_error(self, exc):
+        assert issubclass(exc, ReinfolibError)
+
+    @pytest.mark.parametrize(
+        "exc",
+        [AuthenticationError, InvalidResponseError, NoResultsError, RateLimitError],
+        ids=lambda exc: exc.__name__,
+    )
+    def test_response_bearing_exceptions_are_catchable_as_api_error(self, exc):
+        """One `except APIError` has to cover every failure that came back with a status."""
+        assert issubclass(exc, APIError)
+
+    def test_transport_error_is_not_an_api_error(self):
+        """It has no status code, so code that reads `status_code` must not catch it."""
+        assert not issubclass(TransportError, APIError)


### PR DESCRIPTION
`_get` re-raised whatever `requests` raised, which made `requests` part of this library's public API: a caller had to import it to guard a call site, and replacing the transport later would have broken them. It also left one normal outcome indistinguishable from a fault.

For the three endpoints that do not take tile coordinates (XIT001, XIT002, XCT001), the API answers HTTP 404 when a query matches no data, rather than returning an empty result set. See section 3, Q.8 of the [API manual](https://www.reinfolib.mlit.go.jp/help/apiManual/). "No transactions in 2024 for this city" therefore arrived as a `requests.HTTPError`, the same type as a genuine failure. It is now `NoResultsError`, and the docstrings of the three affected methods say so. Endpoints that do take tile coordinates answer 200 with an empty feature list, so they never raise it.

The new hierarchy:

```
ReinfolibError
├── TransportError           no response was obtained (connection failure, timeout)
└── APIError                 a response arrived; carries status_code, response_body, url
    ├── AuthenticationError  401
    ├── NoResultsError       404
    ├── RateLimitError       429
    └── InvalidResponseError body was not JSON
```

`exceptions.py` imports nothing from `requests`. Translating a response into an exception stays in the client, so the transport remains an implementation detail.

403 is deliberately left as a plain `APIError`. The API manual documents no meaning for it, and the gateway in front of this API uses 401 for a missing or invalid subscription key while reserving 403 for an exhausted call quota. Calling it an authentication failure would send the caller off to check a key that is fine. The body is preserved either way, so the API's own explanation is still readable.

Two changes fall out of this:

- `_get` now uses one `try` per failure stage. The single combined block had to re-derive which stage failed from the exception type, which is how it previously came to dereference a `response` that connection errors and timeouts do not have.
- The `logger.error` before each re-raise is gone. It duplicated what the caller was about to see, and everything it logged is now on the exception as `status_code`, `response_body` and `url`. Anyone who relied on `pyreinfolib.client` log records for monitoring will need to log from their own handler instead.

The four error-handling tests are replaced by coverage of the status-to-exception mapping, the preservation of the response body and URL, the retention of the original exception as `__cause__`, and the invariants of the hierarchy itself. The mapping test pins the exact type rather than using `pytest.raises` alone, which would accept a subclass and let a mismapping of 500 onto `NoResultsError` pass.

BREAKING CHANGE: requests exceptions no longer escape the client. Catch `pyreinfolib.ReinfolibError`, or one of its subclasses, instead of `requests.RequestException`. In particular, a query that matches no data now raises `NoResultsError` instead of `requests.HTTPError` for HTTP 404.
