### PR TITLE
refactor: build query params declaratively

### DIFF
--- a/pyreinfolib/client.py
+++ b/pyreinfolib/client.py
@@ -22,16 +22,34 @@ _STATUS_TO_EXCEPTION: dict[int, type[exceptions.APIError]] = {
 }
 
 
-def _join_codes(codes: Sequence[str] | str) -> str:
+def _join_codes(codes: Sequence[str] | str | None) -> str | None:
     """Serialize one or more codes into the comma separated form the API expects.
 
     A bare string (a `StrEnum` member included) is passed through unchanged. Without this,
     forgetting to wrap a single code in a list would silently send `0,7` instead of `07`,
     because `",".join()` treats the string as a sequence of characters.
+
+    Passes `None` through so that an omitted argument can be handed to `_compact` like any
+    other. An empty sequence becomes an empty string, which `_compact` then drops.
     """
+    if codes is None:
+        return None
     if isinstance(codes, str):
         return codes
     return ",".join(codes)
+
+
+def _compact(params: dict[str, Any]) -> dict[str, Any]:
+    """Drop the entries the API should not receive at all.
+
+    `None` marks an argument the caller left out. An empty string is dropped too, which
+    keeps `city=""` out of the query the way the per-argument `if` checks used to.
+
+    Deliberately not a truthiness test. `x=0` is already a valid tile coordinate, and a
+    future parameter whose valid values include `0` would otherwise vanish from the request
+    with nothing to show why.
+    """
+    return {key: value for key, value in params.items() if value is not None and value != ""}
 
 
 class Client:
@@ -115,19 +133,17 @@ class Client:
         :return: Real estate prices.
         :raises NoResultsError: If no transaction matches the given period and area.
         """
-        params: dict[str, Any] = {"year": year}
-        if price_classification:
-            params["priceClassification"] = price_classification
-        if quarter:
-            params["quarter"] = quarter
-        if area:
-            params["area"] = area
-        if city:
-            params["city"] = city
-        if station:
-            params["station"] = station
-        if language:
-            params["language"] = language
+        params = _compact(
+            {
+                "year": year,
+                "priceClassification": price_classification,
+                "quarter": quarter,
+                "area": area,
+                "city": city,
+                "station": station,
+                "language": language,
+            }
+        )
 
         return self._get("XIT001", params)
 
@@ -139,9 +155,7 @@ class Client:
         :return: Municipality list.
         :raises NoResultsError: If the prefecture code matches no municipality.
         """
-        params: dict[str, Any] = {"area": area}
-        if language:
-            params.update(language=language)
+        params = _compact({"area": area, "language": language})
 
         return self._get("XIT002", params)
 
@@ -182,18 +196,18 @@ class Client:
           See https://www.reinfolib.mlit.go.jp/help/apiManual/#titleApi7
         :return: Real estate prices point. (Response format: GeoJson)
         """
-        params: dict[str, Any] = {
-            "response_format": "geojson",
-            "z": z,
-            "x": x,
-            "y": y,
-            "from": period_from,
-            "to": period_to,
-        }
-        if price_classification:
-            params["priceClassification"] = price_classification
-        if land_type_code:
-            params["landTypeCode"] = _join_codes(land_type_code)
+        params = _compact(
+            {
+                "response_format": "geojson",
+                "z": z,
+                "x": x,
+                "y": y,
+                "from": period_from,
+                "to": period_to,
+                "priceClassification": price_classification,
+                "landTypeCode": _join_codes(land_type_code),
+            }
+        )
 
         return self._get("XPT001", params)
 
@@ -220,11 +234,17 @@ class Client:
         :return: land price public notices (standard land prices) and
         prefectural land price surveys (benchmark land prices) point. (Response format: GeoJson)
         """
-        params: dict[str, Any] = {"response_format": "geojson", "z": z, "x": x, "y": y, "year": year}
-        if price_classification:
-            params["priceClassification"] = price_classification
-        if use_category_code:
-            params["useCategoryCode"] = _join_codes(use_category_code)
+        params = _compact(
+            {
+                "response_format": "geojson",
+                "z": z,
+                "x": x,
+                "y": y,
+                "year": year,
+                "priceClassification": price_classification,
+                "useCategoryCode": _join_codes(use_category_code),
+            }
+        )
 
         return self._get("XPT002", params)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -233,7 +233,7 @@ class TestClient:
                 expected_params={"year": "2025"},
             ),
             RequestCase(
-                id="optional params are omitted when falsy",
+                id="omitted and empty optional params are absent from the query",
                 args={"year": 2025, "price_classification": None, "quarter": None, "city": ""},
                 expected_params={"year": "2025"},
             ),
@@ -348,6 +348,41 @@ class TestClient:
                 expected_params={
                     "response_format": "geojson",
                     "z": "11",
+                    "x": "1819",
+                    "y": "806",
+                    "from": "20241",
+                    "to": "20241",
+                },
+            ),
+            RequestCase(
+                # Filtering the query on truthiness rather than on `None` would drop both
+                # coordinates here and silently request a different tile.
+                id="a zero tile coordinate is still sent",
+                args={"z": 11, "x": 0, "y": 0, "period_from": 20241, "period_to": 20241},
+                expected_params={
+                    "response_format": "geojson",
+                    "z": "11",
+                    "x": "0",
+                    "y": "0",
+                    "from": "20241",
+                    "to": "20241",
+                },
+            ),
+            RequestCase(
+                # `",".join([])` is an empty string, which has to be dropped rather than
+                # sent as `landTypeCode=`.
+                id="an empty land type sequence is omitted",
+                args={
+                    "z": 15,
+                    "x": 1819,
+                    "y": 806,
+                    "period_from": 20241,
+                    "period_to": 20241,
+                    "land_type_code": [],
+                },
+                expected_params={
+                    "response_format": "geojson",
+                    "z": "15",
                     "x": "1819",
                     "y": "806",
                     "from": "20241",


### PR DESCRIPTION
Each method built its query string with a chain of `if` statements, one per optional argument. That is 14 branches whose only job is to decide whether a key belongs in a dict, and it obscured the part that actually carries information: which snake_case argument maps onto which camelCase key the API expects.

`_compact` now drops the entries that should not be sent, and the mapping is a plain dict literal:

```python
params = _compact(
    {
        "year": year,
        "priceClassification": price_classification,
        "quarter": quarter,
        ...
    }
)
```

`_join_codes` passes `None` through, so `landTypeCode` and `useCategoryCode` sit in the same dict as everything else instead of needing their own branch. An empty sequence joins to an empty string, which `_compact` then drops.

`requests` already omits params whose value is `None`, so `_compact` is not strictly required. It is here for two reasons: an empty string has to be dropped as well, which `requests` will not do and which the old `if city:` did, and keeping the filtering explicit means the query that goes out matches the dict that was written, rather than depending on transport behaviour.

This drops the branch count in `client.py` from 28 to 8, and the statement count from 72 to 54. It matters before the remaining endpoints land: there are 32 more in the API, and the alternative is writing another 14-branch chain per method and deleting it later.

### The filter tests `None`, not truthiness

`x=0` is a structurally valid tile coordinate, and a truthiness filter drops it, quietly requesting a different tile. The same trap waits for any future parameter whose valid values include `0`. `_compact` therefore keeps everything except `None` and `""`.

### Behaviour

Verified by driving the previous implementation and this one with the same arguments and comparing the query string that reaches the transport: 1130 argument combinations across all six methods produce byte-identical queries. The combinations cover present, omitted and empty for every optional argument, tile coordinates of zero, and codes passed both bare and as sequences.

The two implementations disagree only for arguments the annotations forbid, where the new behaviour is the better of the two:

| input | before | after |
| --- | --- | --- |
| `quarter=0` | not sent | `quarter=0` |
| `quarter=False` | not sent | `quarter=False` |
| `price_classification=0` | not sent | `priceClassification=0` |

`quarter` is `Literal[1, 2, 3, 4]` and `price_classification` is `Literal["01", "02"]`, so a type checker rejects all three. Letting the API reject the value beats discarding it in silence.

All 47 existing tests pass unmodified. Three cases are added: that a zero tile coordinate is still sent, that an empty code sequence is omitted, and a renamed case describing the actual rule rather than "falsy".

### Not changed here

`city=""` is still dropped silently, so `get_real_estate_prices(year=2025, city="")` returns the whole country rather than complaining. Rejecting it would be an improvement, but it is a behaviour change and belongs in its own pull request.
