### PR TITLE
refactor: extract a shared helper for tile endpoints

### DIFF
--- a/pyreinfolib/client.py
+++ b/pyreinfolib/client.py
@@ -110,6 +110,43 @@ class Client:
                 url=r.url,
             ) from e
 
+    def _get_tile(
+        self,
+        endpoint: str,
+        z: int,
+        x: int,
+        y: int,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Issue a GET against an endpoint addressed by XYZ tile coordinates.
+
+        Most of the published API is addressed this way: `response_format`, `z`, `x` and `y`
+        are all these endpoints have in common, and many accept nothing else. Keeping the
+        shared part here leaves each public method as its docstring plus the handful of
+        parameters that are actually its own.
+
+        `params` is passed as a dict rather than as keyword arguments because two of the
+        keys the API expects, `from` and `to`, are Python keywords.
+
+        `z` is a plain `int` here. The zoom levels each endpoint accepts differ, so the
+        narrow `Literal` belongs on the public method that documents them.
+
+        :param endpoint: Endpoint id, e.g. `XKT015`.
+        :param z: Zoom level (scale).
+        :param x: x value of tile coordinates.
+        :param y: y value of tile coordinates.
+        :param params: Any further query parameters, keyed as the API expects them.
+        :return: The decoded JSON body.
+        """
+        # GeoJson rather than PBF: PBF would need a decoder, and a binary vector tile is not
+        # what a Python caller expecting a dict is after.
+        tile_params: dict[str, Any] = {"response_format": "geojson", "z": z, "x": x, "y": y}
+
+        # Merged so that the shared keys win. A caller has no reason to override them -- it
+        # already passes the coordinates as arguments -- so a collision means a typo in the
+        # `params` dict, and silently honouring it would request the wrong tile.
+        return self._get(endpoint, _compact((params or {}) | tile_params))
+
     def get_real_estate_prices(
         self,
         year: int,
@@ -196,20 +233,18 @@ class Client:
           See https://www.reinfolib.mlit.go.jp/help/apiManual/#titleApi7
         :return: Real estate prices point. (Response format: GeoJson)
         """
-        params = _compact(
+        return self._get_tile(
+            "XPT001",
+            z,
+            x,
+            y,
             {
-                "response_format": "geojson",
-                "z": z,
-                "x": x,
-                "y": y,
                 "from": period_from,
                 "to": period_to,
                 "priceClassification": price_classification,
                 "landTypeCode": _join_codes(land_type_code),
-            }
+            },
         )
-
-        return self._get("XPT001", params)
 
     def get_land_price_public_notices_and_surveys_point(
         self,
@@ -234,19 +269,17 @@ class Client:
         :return: land price public notices (standard land prices) and
         prefectural land price surveys (benchmark land prices) point. (Response format: GeoJson)
         """
-        params = _compact(
+        return self._get_tile(
+            "XPT002",
+            z,
+            x,
+            y,
             {
-                "response_format": "geojson",
-                "z": z,
-                "x": x,
-                "y": y,
                 "year": year,
                 "priceClassification": price_classification,
                 "useCategoryCode": _join_codes(use_category_code),
-            }
+            },
         )
-
-        return self._get("XPT002", params)
 
     def get_number_of_passengers_per_station(
         self,
@@ -261,6 +294,4 @@ class Client:
         :param y: y value of tile coordinates.
         :return: Number of passengers per station. (Response format: GeoJson)
         """
-        params: dict[str, Any] = {"response_format": "geojson", "z": z, "x": x, "y": y}
-
-        return self._get("XKT015", params)
+        return self._get_tile("XKT015", z, x, y)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -467,6 +467,42 @@ class TestClient:
     def test_get_number_of_passengers_per_station(self, mock_api, client, case):
         assert_request(mock_api, client.get_number_of_passengers_per_station, "XKT015", case)
 
+    @pytest.mark.parametrize(
+        ("method_name", "endpoint", "args"),
+        [
+            (
+                "get_real_estate_prices_point",
+                "XPT001",
+                {"z": 11, "x": 1819, "y": 806, "period_from": 20241, "period_to": 20241},
+            ),
+            (
+                "get_land_price_public_notices_and_surveys_point",
+                "XPT002",
+                {"z": 13, "x": 7312, "y": 3008, "year": 2020},
+            ),
+            (
+                "get_number_of_passengers_per_station",
+                "XKT015",
+                {"z": 11, "x": 1819, "y": 806},
+            ),
+        ],
+        ids=["XPT001", "XPT002", "XKT015"],
+    )
+    def test_tile_endpoints_all_send_the_shared_parameters(self, mock_api, client, method_name, endpoint, args):
+        """Asserted across methods rather than per method, because the keys now come from
+        one place. Most of the API is addressed by tile, so a mistake in `_get_tile` would
+        otherwise have to be caught separately for every endpoint added on top of it.
+        """
+        mock_api.get(f"{BASE_URL}{endpoint}", json=DUMMY_RESPONSE)
+
+        getattr(client, method_name)(**args)
+
+        params = mock_api.calls[0].request.params
+        assert params["response_format"] == "geojson"
+        assert params["z"] == str(args["z"])
+        assert params["x"] == str(args["x"])
+        assert params["y"] == str(args["y"])
+
 
 class TestExceptions:
     """The shape of the hierarchy is public API: callers catch these instead of `requests`."""


### PR DESCRIPTION
Of the 38 endpoints the API publishes, 33 are addressed by XYZ tile coordinates, and most of those accept nothing beyond `response_format`, `z`, `x` and `y`. Three are implemented so far, and each spelled that shared part out for itself. Repeating it another 30 times would bury the only per-endpoint information that matters, which is the endpoint id, the zoom levels it accepts, and its docstring.

`_get_tile` now holds the shared part. `get_number_of_passengers_per_station`, which takes nothing else, is a single line:

```python
def get_number_of_passengers_per_station(self, z, x, y):
    """..."""
    return self._get_tile("XKT015", z, x, y)
```

The `response_format": "geojson"` literal goes from three places to one.

Three decisions worth flagging:

- `params` is a dict, not `**kwargs`. Two of the keys the API expects, `from` and `to`, are Python keywords and cannot be parameter names.
- `z` is a plain `int` on the helper. The zoom levels differ per endpoint -- XPT001 accepts 11 through 15, XPT002 only 13 through 15 -- so the narrow `Literal` stays on the public method whose docstring documents the range.
- The merge is `(params or {}) | tile_params`, so the shared keys win. A caller passes the coordinates as arguments and has no reason to override them, which means a collision is a typo in the `params` dict. Honouring it silently would request the wrong tile.

PBF is left out. The API offers it, but it would need a decoder, and a binary vector tile is not what a caller expecting a dict is after.

### Behaviour

Verified by driving the implementation on `main` and this one with the same arguments, then comparing both the endpoint path and the query string that reaches the transport: 1238 argument combinations across all six methods are identical. The combinations cover every documented zoom level, tile coordinates of zero, codes passed bare and as sequences including the full enum, and the three non-tile endpoints that share `_get` but not `_get_tile`. The endpoint path is compared because this change moves the endpoint ids into `_get_tile` calls.

All 49 existing tests pass unmodified. One test is added, covering all three endpoints at once: the shared keys now come from a single place, so a mistake in `_get_tile` affects every endpoint built on it, and that is better asserted across methods than rediscovered per method.

### Does the helper generalise?

Checked rather than assumed. Two of the unimplemented endpoints were prototyped against it -- XKT002, which takes nothing beyond the coordinates, and XKT013, which takes a `year` -- and both produce the correct request with a one-line method body.

### Not changed here

The zoom level `Literal` is still written out per method. Most of the remaining 30 tile endpoints will want `Literal[11, 12, 13, 14, 15]`, so an alias would pay off, but XPT002 shows the ranges are not uniform and a single alias will not cover them. That is a separate concern from extracting the helper, and is better done just before the endpoints land.
