### PR TITLE
feat!: accept enums for price classification codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ client = Client(api_key=os.environ["REINFOLIB_API_KEY"])
 ### 不動産価格（取引価格・成約価格）情報
 
 ```python
-client.get_real_estate_prices(year=2024, quarter=1, price_classification="01", city="13109")
+from pyreinfolib.enums import PriceClassification
+
+client.get_real_estate_prices(
+    year=2024,
+    quarter=1,
+    price_classification=PriceClassification.REAL_ESTATE_TRANSACTION_PRICE,
+    city="13109",
+)
 ```
 
 ### 鑑定評価書情報
@@ -86,7 +93,16 @@ except APIError as e:
 
 型情報を同梱しています（[PEP 561](https://peps.python.org/pep-0561/)）。
 
-`division`、`land_type_code`、`use_category_code` には `pyreinfolib.enums` の enum メンバーを渡してください。`StrEnum` なので実行時は文字列でも動きますが、型チェックでは拒否されます。単一のコードはリストに包む必要はありません。
+`price_classification`、`division`、`land_type_code`、`use_category_code` には `pyreinfolib.enums` の enum メンバーを渡してください。`StrEnum` なので実行時は文字列でも動きますが、型チェックでは拒否されます。単一のコードはリストに包む必要はありません。
+
+`price_classification` は API 上どのエンドポイントでも `priceClassification` という同じ名前ですが、コード体系は2つに分かれています。
+
+| enum | 対象 | コード |
+|---|---|---|
+| `PriceClassification` | 不動産価格（XIT001、XPT001） | `01` 不動産取引価格情報 / `02` 成約価格情報 |
+| `LandPriceClassification` | 地価公示・地価調査（XPT002） | `0` 地価公示 / `1` 都道府県地価調査 |
+
+別の型にしてあるので、取り違えは型チェックで検出されます。誤ったコードを送った場合、API はエラーではなく絞り込まれた結果や空の結果を返すため、実行時には気づきにくい種類の間違いです。
 
 ## Author
 

--- a/pyreinfolib/client.py
+++ b/pyreinfolib/client.py
@@ -150,7 +150,7 @@ class Client:
     def get_real_estate_prices(
         self,
         year: int,
-        price_classification: Literal["01", "02"] | None = None,
+        price_classification: enums.PriceClassification | None = None,
         quarter: Literal[1, 2, 3, 4] | None = None,
         area: str | None = None,
         city: str | None = None,
@@ -158,9 +158,8 @@ class Client:
         language: Literal["ja", "en"] | None = None,
     ) -> dict[str, Any]:
         """Get real estate prices. See https://www.reinfolib.mlit.go.jp/help/apiManual/#titleApi4 for details.
-        :param price_classification: Price classification code.
-          01: Real estate transaction price information, 02: Contract price information,
-          Unspecified: Both transaction price information and contract price information.
+        :param price_classification: Price classification.
+          If not specified, both real estate transaction prices and contract prices.
         :param year: Transaction period (Year).
         :param quarter: Transaction period (Quarter). 1: Jan.~Mar. 2: Apr.~Jun. 3: Jul.~Sep. 4: Oct.~Dec.
         :param area: Prefecture code. See https://nlftp.mlit.go.jp/ksj/gml/codelist/PrefCd.html
@@ -216,7 +215,7 @@ class Client:
         y: int,
         period_from: int,
         period_to: int,
-        price_classification: Literal["01", "02"] | None = None,
+        price_classification: enums.PriceClassification | None = None,
         land_type_code: Sequence[enums.LandTypeCode] | enums.LandTypeCode | None = None,
     ) -> dict[str, Any]:
         """Get real estate prices point.
@@ -226,9 +225,8 @@ class Client:
         :param y: y value of tile coordinates.
         :param period_from: Transaction period from. Format: YYYYN. e.g. 20241
         :param period_to: Transaction period to. Format: YYYYN. e.g. 20242
-        :param price_classification: Price classification code.
-          01: Real estate transaction price information, 02: Contract price information,
-          Unspecified: Both transaction price information and contract price information.
+        :param price_classification: Price classification.
+          If not specified, both real estate transaction prices and contract prices.
         :param land_type_code: One land type code, or a sequence of them.
           See https://www.reinfolib.mlit.go.jp/help/apiManual/#titleApi7
         :return: Real estate prices point. (Response format: GeoJson)
@@ -252,7 +250,7 @@ class Client:
         x: int,
         y: int,
         year: int,
-        price_classification: Literal["0", "1"] | None = None,
+        price_classification: enums.LandPriceClassification | None = None,
         use_category_code: Sequence[enums.UseDivision] | enums.UseDivision | None = None,
     ) -> dict[str, Any]:
         """Get land price public notices (standard land prices) and
@@ -262,8 +260,10 @@ class Client:
         :param x: x value of tile coordinates.
         :param y: y value of tile coordinates.
         :param year: target year.
-        :param price_classification: Land price classification code.
-          0: Land price public notices, 1: Prefectural land price surveys, Unspecified: Both 0 and 1.
+        :param price_classification: Land price classification. Note that this is
+          `LandPriceClassification`, a different code table from the `PriceClassification`
+          the real estate price endpoints take. If not specified, both land price public
+          notices and prefectural land price surveys.
         :param use_category_code: One use division code, or a sequence of them.
           See https://www.reinfolib.mlit.go.jp/help/apiManual/#titleApi8
         :return: land price public notices (standard land prices) and

--- a/pyreinfolib/enums.py
+++ b/pyreinfolib/enums.py
@@ -2,6 +2,36 @@ from enum import StrEnum, unique
 
 
 @unique
+class PriceClassification(StrEnum):
+    """Price classification for the real estate price endpoints, XIT001 and XPT001.
+
+    Leaving the argument unset asks for both.
+    """
+
+    # 不動産取引価格情報
+    REAL_ESTATE_TRANSACTION_PRICE = "01"
+
+    # 成約価格情報
+    CONTRACT_PRICE = "02"
+
+
+@unique
+class LandPriceClassification(StrEnum):
+    """Land price classification for the land price endpoint, XPT002.
+
+    A separate code table from `PriceClassification`, numbered from `0` rather than `01`, so
+    the two are not interchangeable even though the API spells both `priceClassification`.
+    Leaving the argument unset asks for both.
+    """
+
+    # 地価公示
+    LAND_PRICE_PUBLIC_NOTICE = "0"
+
+    # 都道府県地価調査
+    PREFECTURAL_LAND_PRICE_SURVEY = "1"
+
+
+@unique
 class UseDivision(StrEnum):
     # 住宅地
     RESIDENTIAL_LAND = "00"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -7,7 +7,7 @@ import requests
 import responses
 
 from pyreinfolib import Client
-from pyreinfolib.enums import LandTypeCode, UseDivision
+from pyreinfolib.enums import LandPriceClassification, LandTypeCode, PriceClassification, UseDivision
 from pyreinfolib.exceptions import (
     APIError,
     AuthenticationError,
@@ -210,7 +210,7 @@ class TestClient:
                 id="all params",
                 args={
                     "year": 2025,
-                    "price_classification": "01",
+                    "price_classification": PriceClassification.REAL_ESTATE_TRANSACTION_PRICE,
                     "quarter": 1,
                     "area": "13",
                     "city": "13109",
@@ -287,7 +287,7 @@ class TestClient:
                     "y": 806,
                     "period_from": 20241,
                     "period_to": 20242,
-                    "price_classification": "01",
+                    "price_classification": PriceClassification.REAL_ESTATE_TRANSACTION_PRICE,
                     "land_type_code": [LandTypeCode.LAND, LandTypeCode.FOREST_LAND],
                 },
                 expected_params={
@@ -405,7 +405,7 @@ class TestClient:
                     "x": 7312,
                     "y": 3008,
                     "year": 2020,
-                    "price_classification": "0",
+                    "price_classification": LandPriceClassification.LAND_PRICE_PUBLIC_NOTICE,
                     "use_category_code": [UseDivision.RESIDENTIAL_LAND, UseDivision.COMMERCIAL_LAND],
                 },
                 expected_params={
@@ -527,3 +527,20 @@ class TestExceptions:
     def test_transport_error_is_not_an_api_error(self):
         """It has no status code, so code that reads `status_code` must not catch it."""
         assert not issubclass(TransportError, APIError)
+
+
+class TestEnums:
+    def test_the_two_price_classification_tables_stay_distinct(self):
+        """XPT002 numbers its codes from `0`, XIT001 and XPT001 from `01`.
+
+        The API spells the parameter `priceClassification` in all three, which invites
+        folding the two tables into one enum. Sending `01` where `0` is expected is answered
+        with a filtered or empty result rather than an error, so the mistake would not
+        surface at the call site.
+        """
+        price_codes = {member.value for member in PriceClassification}
+        land_price_codes = {member.value for member in LandPriceClassification}
+
+        assert price_codes == {"01", "02"}
+        assert land_price_codes == {"0", "1"}
+        assert not price_codes & land_price_codes


### PR DESCRIPTION
`price_classification` was annotated `Literal["01", "02"]`, or `Literal["0", "1"]` on the land price endpoint. Those codes carry no meaning at the call site: `"02"` says nothing about 成約価格情報. The library already solves this for the other code parameters -- `division`, `land_type_code` and `use_category_code` all take `StrEnum` members from `pyreinfolib.enums` -- and the README already states that as the convention. `price_classification` was the one that had not caught up.

Two enums are added, named from the API's own code tables:

```python
@unique
class PriceClassification(StrEnum):       # XIT001, XPT001
    REAL_ESTATE_TRANSACTION_PRICE = "01"  # 不動産取引価格情報
    CONTRACT_PRICE = "02"                 # 成約価格情報

@unique
class LandPriceClassification(StrEnum):   # XPT002
    LAND_PRICE_PUBLIC_NOTICE = "0"        # 地価公示
    PREFECTURAL_LAND_PRICE_SURVEY = "1"   # 都道府県地価調査
```

### Why two, and not one

The API spells the parameter `priceClassification` on all three endpoints, but the code tables differ: XIT001 and XPT001 number from `01`, XPT002 from `0`. Folding them into one enum would send `01` where `0` is expected.

That failure is quiet. The API answers a wrong-but-well-formed code with a filtered or empty result, not an error, so nothing surfaces at the call site. Keeping them as separate types moves the mistake to type-check time.

### Verified

Eight call sites were type-checked, and exactly the four intended errors were reported:

| call | result |
| --- | --- |
| `price_classification=PriceClassification.CONTRACT_PRICE` | accepted |
| argument omitted | accepted |
| `price_classification="01"` | rejected, bare code string |
| `get_real_estate_prices_point(..., price_classification="02")` | rejected, bare code string |
| `LandPriceClassification` on XPT002 | accepted |
| `PriceClassification` on XPT002 | rejected, wrong code table |
| `LandPriceClassification` on XIT001 | rejected, wrong code table |

Rejecting the table mix-up in both directions is what the split buys.

`ruff`, `mypy` and 53 tests pass, with full branch coverage of the package.

### Tests

The existing cases passed bare `"01"` and `"0"`. Those keep working at runtime, because a `StrEnum` member is a `str` and `mypy` does not check the test suite, so the change would otherwise have gone unnoticed there. They now pass enum members, matching how `division` and the others are already exercised.

One case is added, asserting the two code tables have no values in common. It exists to record that consolidating them -- a tempting move, given the API uses one parameter name -- breaks things silently.

### Docs

The `## Example` snippet in the README passed `price_classification="01"`, which no longer type-checks, and is updated. `## Typing` gains a table mapping each enum to its endpoints and codes.

BREAKING CHANGE: `price_classification` no longer accepts a bare code string. Pass `pyreinfolib.enums.PriceClassification` on `get_real_estate_prices` and `get_real_estate_prices_point`, and `pyreinfolib.enums.LandPriceClassification` on `get_land_price_public_notices_and_surveys_point`. A `StrEnum` member is a `str`, so existing calls keep working at runtime; it is type checking that now rejects them.
