### PR TITLE
docs: document the naming rule and the terminology glossary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,5 +113,8 @@ cython_debug/
 # InelliJ
 .idea/
 
+# Kiro
+.kiro/
+
 # MacOS
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,158 @@
+# Contributing
+
+## 開発環境
+
+```shell
+uv sync --locked
+uv run ruff check .
+uv run ruff format --check .
+uv run pytest
+```
+
+CI が実行するのはこの4つです。型情報を同梱しているため（[PEP 561](https://peps.python.org/pep-0561/)）、型注釈は公開APIの一部として扱います。
+
+## プルリクエスト
+
+squash merge のみを使います。リポジトリ設定が `squash_merge_commit_title: PR_TITLE` / `squash_merge_commit_message: PR_BODY` なので、**PR のタイトルと説明文がそのまま `main` のコミットメッセージになります**。
+
+- タイトルは [Conventional Commits](https://www.conventionalcommits.org/) 準拠。`.github/workflows/pr-title.yml` が検証します
+- release-please がタイトルからバージョンと CHANGELOG を生成します。`feat` は minor、`fix` は patch、`!` 付きは破壊的変更（1.0 到達前は minor）
+- 破壊的変更は説明文の末尾に `BREAKING CHANGE: <移行手順>` のフッタを書いてください。CHANGELOG の BREAKING CHANGES に載ります
+- 説明文が git 履歴に残るため、レビュー用のチェックリストや議論の経緯は書かないでください
+
+## 命名
+
+メソッド名・引数名・enum 名は、**不動産情報ライブラリの[API操作説明](https://www.reinfolib.mlit.go.jp/help/apiManual/)に載っている API 名から機械的に導出します**。読みやすさを基準に選びません。
+
+理由は3つあります。
+
+API 名は外部にある唯一の安定した共有語彙です。利用者が読むのは MLIT のマニュアルであって、このライブラリのソースではありません。マニュアルの API 一覧を見ている人が対応するメソッドを推測できる状態に価値があります。
+
+公開APIは38本あります。読みやすさを基準にすると38回の裁量判断が必要で、必ず途中でぶれます。
+
+API 側が改称したとき、追随すべきかの判断がつきます。
+
+### 導出手順
+
+1. API 名から始める
+2. **出典を落とす。** 国土数値情報、都市計画決定GISデータ、国土地理院GISデータ、国土調査、国土交通省都市局は、誰が公開したデータかを示すもので、何のデータかを示していない
+3. **主題を言い換えただけの括弧を落とす。** 不動産価格（取引価格・成約価格）の括弧は 不動産価格 の内訳なので落とす
+4. **括弧の中身がデータセット名なら残す。** 出典が主題の位置に来ている場合（手順2で頭を落とした場合）はこちら。国土数値情報（駅別乗降客数）→ 駅別乗降客数
+5. **定型辞を落とす。** 情報、取得、一覧、API
+6. **必須引数で表現されている限定を落とす。** 都道府県内市区町村一覧 の 都道府県内 は `area` 引数が表すので落とす
+7. **トップレベルの「・」は `and` として残す。** 地価公示・地価調査 はどちらも独立したデータセットなので両方残す。手順3の括弧内の「・」とは違う
+8. **「ポイント (点)」は `_point` として残す。** XPT001 と XPT002 だけが持つ
+9. 残った語を用語集で訳す
+10. `get_` を付ける
+
+### 長さは基準にしません
+
+手順の結果が長くても短縮しません。短縮するかを毎回判断すると、判断のぶれが名前のぶれになります。`get_land_price_public_notices_and_surveys_point` は規則を守った結果として正しい名前です。
+
+### 単数・複数
+
+- **メソッド名**は返り値に合わせます。一覧が返るなら複数（`get_municipalities`）
+- **enum メンバー**は単数です（`RESIDENTIAL_LAND`、`LAND_AND_BUILDING`）
+
+### 導出例
+
+規則が既存の6メソッドを再現することを確認済みです。
+
+| ID | API 名 | 落とした部分 | メソッド名 |
+|---|---|---|---|
+| XIT001 | 不動産価格（取引価格・成約価格）情報取得API | 括弧（手順3）、情報取得 | `get_real_estate_prices` |
+| XIT002 | 都道府県内市区町村一覧取得API | 都道府県内（手順6）、一覧取得 | `get_municipalities` |
+| XCT001 | 鑑定評価書情報API | 情報 | `get_appraisal_reports` |
+| XPT001 | 不動産価格（取引価格・成約価格）情報のポイント (点) API | 括弧（手順3）、情報 | `get_real_estate_prices_point` |
+| XPT002 | 地価公示・地価調査のポイント (点) API | なし | `get_land_price_public_notices_and_surveys_point` |
+| XKT015 | 国土数値情報（駅別乗降客数）API | 国土数値情報（手順2） | `get_number_of_passengers_per_station` |
+
+## enum
+
+### enum にするか `Literal` にするか
+
+**コードそれ自体に意味が読み取れないものは enum にします。** `"02"` は 成約価格情報 を意味しますが、呼び出し側からは何も読み取れません。
+
+**値に意味が読み取れるものは `Literal` のままにします。** `quarter: Literal[1, 2, 3, 4]`、`language: Literal["ja", "en"]`、`z: Literal[11, 12, 13, 14, 15]` はそのままで十分です。
+
+`StrEnum` を使います。実行時は文字列としても動くので、型チェックだけが新しい制約になります。
+
+### コード体系が別なら enum も分けます
+
+API が同じパラメータ名を使っていても、コード表が違えば別の enum にします。`priceClassification` は XIT001/XPT001 では `01`/`02`、XPT002 では `0`/`1` です。1つにまとめると `01` を `0` の位置に送れてしまい、API はエラーではなく空の結果を返すため気づけません。
+
+### メンバー名
+
+用語集で訳し、日本語のコード表記をコメントで添えます。
+
+```python
+@unique
+class PriceClassification(StrEnum):
+    # 不動産取引価格情報
+    REAL_ESTATE_TRANSACTION_PRICE = "01"
+
+    # 成約価格情報
+    CONTRACT_PRICE = "02"
+```
+
+## 用語集
+
+### 典拠の優先順位
+
+1. **[日本法令外国語訳データベースシステム](https://www.japaneselawtranslation.go.jp/)**（法務省）。今回必要な語の多くは法令用語で、政府公式訳が条文単位で日英対応しています
+2. **所管省庁の英語版資料**。法令用語でないもの（統計用語、データセット名）
+3. **既にこのライブラリで使っている訳語**。1と2で確認できないもの
+
+### 確定
+
+| 日本語 | English | 典拠 |
+|---|---|---|
+| 用途地域 | use district | 建築基準法48条（[/laws/view/4024](https://www.japaneselawtranslation.go.jp/ja/laws/view/4024/je)） |
+| 防火地域 | fire prevention district | 建築基準法53条3項 |
+| 準防火地域 | quasi-fire prevention district | 建築基準法53条3項 |
+| 高度利用地区 | high-level use district | 建築基準法59条 |
+| 高度地区 | height control district | 建築基準法58条 |
+| 都市計画区域 | city planning area | 都市計画法5条（[/laws/view/3841](https://www.japaneselawtranslation.go.jp/ja/laws/view/3841/je)） |
+| 区域区分 | area classification | 都市計画法7条 |
+| 市街化区域 | urbanization promotion area | 都市計画法7条 |
+| 市街化調整区域 | urbanization control area | 都市計画法7条 |
+| 地区計画 | district plan | 都市計画法12条の4 |
+
+用途地域の内訳（13種）も同じ典拠から取れます。第一種低層住居専用地域 = category 1 low-rise exclusive residential district、準住居地域 = quasi-residential district、田園住居地域 = countryside residential district、準工業地域 = quasi-industrial district、工業専用地域 = exclusive industrial district、ほか。
+
+### 注意: 用途地域と用途区分は別の語彙です
+
+鑑定評価書API（XCT001）の `division`（`UseDivision`）は**地価公示の用途区分**で、都市計画法の**用途地域**ではありません。
+
+- 準工業**地**（`QUASI_INDUSTRIAL_LAND`）≠ 準工業**地域**（quasi-industrial district）
+- 現況林地、宅地見込地 も用途地域には存在しません
+
+用語集を機械的に当てて `UseDivision` を district に「直す」のは誤りです。
+
+### 未確定
+
+根拠法・典拠候補まで特定済みです。確定したらこの表から上の表へ移してください。
+
+| 用語 | 典拠を探す先 | 用途 |
+|---|---|---|
+| 地価公示 | 地価公示法 | XPT002、既存名で `land_price_public_notice` を使用中（未検証） |
+| 都道府県地価調査 | 国土利用計画法施行令 | XPT002、既存名で `prefectural_land_price_survey` を使用中（未検証） |
+| 立地適正化計画 | 都市再生特別措置法 | XKT003 |
+| 災害危険区域 | 建築基準法39条 | XKT016 |
+| 自然公園地域 | 自然公園法 | XKT019 |
+| 大規模盛土造成地 | 国土交通省 | XKT020 |
+| 地すべり防止区域 | 地すべり等防止法 | XKT021 |
+| 急傾斜地崩壊危険区域 | 急傾斜地法 | XKT022 |
+| 地形区分に基づく液状化の発生傾向図 | 国土交通省都市局 | XKT025 |
+| 洪水浸水想定区域 | 水防法 | XKT026 |
+| 高潮浸水想定区域 | 水防法 | XKT027 |
+| 津波浸水想定 | 津波防災地域づくり法 | XKT028 |
+| 土砂災害警戒区域 | 土砂災害防止法 | XKT029 |
+| 都市計画道路 | 都市計画法（簡潔な定訳がなく判断が必要） | XKT030 |
+| 人口集中地区 | 総務省統計局（国勢調査英語版で Densely Inhabited District / DID が定着） | XKT031 |
+| 指定緊急避難場所 | 災害対策基本法 | XGT001 |
+| 災害履歴 | 国土調査（土地履歴調査） | XST001 |
+
+XKT004〜018 の施設系（小学校区、学校、保育園・幼稚園等、医療機関、福祉施設、図書館、市区町村役場及び集会施設等）は一般語なので法令典拠は不要です。
+
+**地価公示 と 都道府県地価調査 は優先度が高いです。** 既に公開済みのメソッド名と enum メンバー名に使っているため、公式訳が違っていた場合の修正は破壊的変更になります。1.0 到達前に確定させてください。

--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ except APIError as e:
 
 別の型にしてあるので、取り違えは型チェックで検出されます。誤ったコードを送った場合、API はエラーではなく絞り込まれた結果や空の結果を返すため、実行時には気づきにくい種類の間違いです。
 
+## Contributing
+
+メソッド名や enum メンバー名は、API 操作説明の API 名から機械的に導出しています。導出手順と訳語の用語集は [CONTRIBUTING.md](CONTRIBUTING.md) にあります。
+
 ## Author
 
 @matsudan (daaamatsun@gmail.com)


### PR DESCRIPTION
Adds `CONTRIBUTING.md`, covering the naming rule, the terminology glossary, and the conventions established over #35 through #39.

### Why the naming rule needs writing down

The API publishes 38 endpoints and 6 are implemented. The remaining 32 need names, and the naming decision recurs 32 times. A rule based on readability requires 32 judgement calls and will drift; a rule derived from the API name is mechanical.

This is not hypothetical. A rename of `get_land_price_public_notices_and_surveys_point` to `get_land_prices_point` was proposed and abandoned during this work: it was justified by symmetry with the sibling `get_real_estate_prices_point`, but that symmetry is coincidental. XPT001 covers 不動産価格 while XPT002 covers 地価公示 and 地価調査; the API's own vocabulary does not pair them as "real estate prices" against "land prices". Anchoring on internal aesthetics rather than the published API name produced the wrong answer.

The rule is ten steps. The substantive ones: drop the source prefix (国土数値情報, 都市計画決定GISデータ and the like identify the publisher, not the data), drop a parenthetical that only restates the head term, keep a parenthetical that is itself the dataset name, drop the boilerplate (情報, 取得, 一覧, API), drop a qualifier already expressed by a required argument, and keep a top-level 「・」 as `and`.

Length is explicitly not a criterion. Deciding whether to shorten, case by case, turns variance in judgement into variance in names.

Verified: the rule reproduces all six existing method names. `get_municipalities` is the interesting one, because 都道府県内 is dropped only because the `area` argument expresses it, which is what step 6 exists for.

### Glossary

The strongest source is the [Japanese Law Translation Database](https://www.japaneselawtranslation.go.jp/) run by the Ministry of Justice: most of the terms needed are statutory, and it pairs Japanese and English article by article, so there is no room for invention.

Ten terms are settled with citations, from the Building Standards Act and the City Planning Act. Seventeen are open, each listed with the act or ministry that governs it, so the source to check is not itself a research question.

Two of the open ones matter more than the rest. 地価公示 and 都道府県地価調査 are already used in a published method name and in `LandPriceClassification` members, and I could not verify either against an official translation. If the official term differs, correcting it is a breaking change, so it should be settled before 1.0.

A separate caveat is called out: the appraisal report `division` codes (`UseDivision`) are 地価公示の用途区分, not the City Planning Act's 用途地域. 準工業**地** is not 準工業**地域**, and 現況林地 and 宅地見込地 have no Use District equivalent. Applying the glossary mechanically and "correcting" `QUASI_INDUSTRIAL_LAND` to a district would be wrong, so the trap is documented next to the rule that leads to it.

### The rest of the file

The development commands and the pull request conventions had lived only in workflow comments until now. They are verified against the repository rather than transcribed: the four commands match `ci.yml` exactly, and the squash settings quoted match the repository's actual `PR_TITLE` / `PR_BODY` configuration.

Also verified: every method name in the derivation table exists on `Client`, with no public method missing from the table, and the relative links resolve.

`README.md` gains a four-line pointer to the new file.
