### PR TITLE
feat: reuse HTTP connections and retry throttled requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,25 @@ from pyreinfolib import Client
 client = Client(api_key=os.environ["REINFOLIB_API_KEY"])
 ```
 
+`Client` はコネクションを再利用します。タイル系APIを複数タイル分呼ぶような使い方では、TLSハンドシェイクが1回で済みます。使い終わったら `close()` するか、`with` を使ってください。
+
+```python
+with Client(api_key=os.environ["REINFOLIB_API_KEY"]) as client:
+    client.get_municipalities(area="13")
+```
+
+### リトライ
+
+スロットリング（HTTP 429）と一時的なサーバエラー（500、502、503、504）は自動で再試行します。APIはリクエスト数の明確な上限を公開しておらず、間隔を空けて実行するよう案内しているため、429 は障害ではなく想定される応答です。
+
+待ち時間は指数的に伸びます。既定の `max_retries=3` では 0秒、2秒、4秒の順に待ち、4回目で諦めて `RateLimitError` を送出します。APIが `Retry-After` を返した場合はそちらが優先されます。
+
+```python
+# 再試行しない
+client = Client(api_key=..., max_retries=0)
+```
+
+検索結果0件（HTTP 404）は再試行しません。`timeout` は各試行を制限するもので、再試行の全体を制限するものではありません。
 
 ## Example
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,11 @@ authors = [
 dynamic = ["version"]
 dependencies = [
     "requests",
+    # `urllib3.util.Retry` is used directly to configure the client's retry policy. It
+    # arrives with requests either way, but declaring what is imported keeps the resolver
+    # honest. `requests.adapters.Retry` is the same object, but it is an incidental import
+    # in requests rather than part of its public API.
+    "urllib3>=1.26",
 ]
 readme = "README.md"
 requires-python = ">= 3.11"

--- a/pyreinfolib/client.py
+++ b/pyreinfolib/client.py
@@ -1,12 +1,25 @@
 from collections.abc import Sequence
-from typing import Any, Literal
+from types import TracebackType
+from typing import Any, Literal, Self
 from urllib.parse import urljoin
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
 
 from pyreinfolib import enums, exceptions
 
 DEFAULT_TIMEOUT = 30.0
+DEFAULT_MAX_RETRIES = 3
+
+# Statuses worth another attempt. 429 is the one the API documents: it publishes no request
+# ceiling and instead asks that calls be spaced out, so being throttled is an expected
+# outcome rather than a fault. See section 3, Q.3 of
+# https://www.reinfolib.mlit.go.jp/help/apiManual/
+#
+# 404 is deliberately absent. It means the query matched no data, so retrying it would only
+# wait to be told the same thing again.
+_RETRY_STATUSES = (429, 500, 502, 503, 504)
 
 # Statuses whose meaning the API documents. Anything else falls back to `APIError`, which
 # still carries the body, so the caller can read the API's own explanation.
@@ -53,21 +66,73 @@ def _compact(params: dict[str, Any]) -> dict[str, Any]:
 
 
 class Client:
-    def __init__(self, api_key: str, timeout: float | tuple[float, float] = DEFAULT_TIMEOUT) -> None:
+    def __init__(
+        self,
+        api_key: str,
+        timeout: float | tuple[float, float] = DEFAULT_TIMEOUT,
+        max_retries: int = DEFAULT_MAX_RETRIES,
+    ) -> None:
         """
         :param api_key: API key issued for the Real Estate Information Library.
         :param timeout: Request timeout in seconds, passed straight to `requests`.
           A single value applies to both connect and read, or pass a `(connect, read)` tuple.
-        :raises ValueError: If `api_key` is empty.
+          It bounds each attempt, not the sequence of retries.
+        :param max_retries: How many further attempts a throttled or briefly failing request
+          gets. Pass 0 to retry nothing. Waits between attempts grow exponentially, and a
+          `Retry-After` header from the API takes precedence over that.
+        :raises ValueError: If `api_key` is empty, or `max_retries` is negative.
         """
         # Reject it here rather than on the first request, where an empty or missing key
         # surfaces as a 401 that gives no hint about the actual cause.
         if not api_key:
             raise ValueError("`api_key` must be a non-empty string.")
+        if max_retries < 0:
+            raise ValueError("`max_retries` must not be negative.")
 
         self.api_key = api_key
         self.base_url = "https://www.reinfolib.mlit.go.jp/ex-api/external/"
         self.timeout = timeout
+
+        # One session for the whole client, so that a caller walking a tile grid reuses the
+        # connection instead of completing a TLS handshake per tile.
+        self._session = requests.Session()
+        self._session.headers["Ocp-Apim-Subscription-Key"] = api_key
+        adapter = HTTPAdapter(
+            max_retries=Retry(
+                total=max_retries,
+                status_forcelist=_RETRY_STATUSES,
+                backoff_factor=1.0,
+                # Hand the exhausted response back rather than raising, so that `_get` can
+                # translate it. urllib3 would otherwise raise, requests would wrap that in
+                # `RetryError`, and a request throttled to the last attempt would reach the
+                # caller as `TransportError` instead of `RateLimitError`.
+                raise_on_status=False,
+            )
+        )
+        # Both schemes, although the API is https only. `base_url` is a public attribute, so
+        # pointing a client at a local double over http is possible, and retrying is a
+        # property of the client rather than of the scheme it happens to be talking over.
+        self._session.mount("https://", adapter)
+        self._session.mount("http://", adapter)
+
+    def close(self) -> None:
+        """Release the connection pool.
+
+        Not needed for correctness, but a client left open holds its sockets until it is
+        garbage collected, which surfaces as a `ResourceWarning`.
+        """
+        self._session.close()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        self.close()
 
     def _get(self, endpoint: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
         """Issue a GET against `endpoint` and return the decoded JSON body.
@@ -80,14 +145,13 @@ class Client:
         :raises APIError: For any other error status.
         """
         api_url = urljoin(self.base_url, endpoint)
-        headers = {"Ocp-Apim-Subscription-Key": self.api_key}
 
         # Each failure mode gets its own `try`. Wrapping the whole exchange in one block
         # would have to re-derive which stage failed from the exception type, which is how
         # the previous version came to dereference a `response` that connection errors and
         # timeouts do not have.
         try:
-            r = requests.get(api_url, headers=headers, params=params, timeout=self.timeout)
+            r = self._session.get(api_url, params=params, timeout=self.timeout)
         except requests.RequestException as e:
             raise exceptions.TransportError(f"Request to {api_url} failed: {e}") from e
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,6 +5,7 @@ from typing import Any
 import pytest
 import requests
 import responses
+from urllib3.util import Retry
 
 from pyreinfolib import Client
 from pyreinfolib.enums import LandPriceClassification, LandTypeCode, PriceClassification, UseDivision
@@ -22,6 +23,8 @@ BASE_URL = "https://www.reinfolib.mlit.go.jp/ex-api/external/"
 API_KEY = "dummy"
 DUMMY_RESPONSE = {"status": "OK", "data": []}
 DEFAULT_TIMEOUT = 30.0
+DEFAULT_MAX_RETRIES = 3
+THROTTLED = {"json": {"message": "slow down"}, "status": 429}
 
 
 @dataclass
@@ -50,7 +53,17 @@ def mock_api():
 
 @pytest.fixture
 def client():
-    return Client(api_key=API_KEY)
+    # Closed on teardown: the client now owns a connection pool, and leaving one open per
+    # test would leak sockets across the suite.
+    with Client(api_key=API_KEY) as client:
+        yield client
+
+
+def retries_of(client: Client) -> Retry:
+    """The retry policy the client actually mounted, as the transport sees it."""
+    adapter = client._session.get_adapter(BASE_URL)
+    assert isinstance(adapter.max_retries, Retry)
+    return adapter.max_retries
 
 
 def assert_request(mock_api: responses.RequestsMock, method: Callable, endpoint: str, case: RequestCase) -> None:
@@ -69,20 +82,72 @@ def assert_request(mock_api: responses.RequestsMock, method: Callable, endpoint:
 
 class TestClient:
     def test_init(self):
-        client = Client(api_key="dummy")
-        assert client.api_key == "dummy"
-        assert client.base_url == BASE_URL
-        assert client.timeout == DEFAULT_TIMEOUT
+        with Client(api_key="dummy") as client:
+            assert client.api_key == "dummy"
+            assert client.base_url == BASE_URL
+            assert client.timeout == DEFAULT_TIMEOUT
+            assert retries_of(client).total == DEFAULT_MAX_RETRIES
 
     def test_init_accepts_custom_timeout(self):
-        assert Client(api_key="dummy", timeout=5).timeout == 5
-        assert Client(api_key="dummy", timeout=(3.0, 10.0)).timeout == (3.0, 10.0)
+        with Client(api_key="dummy", timeout=5) as client:
+            assert client.timeout == 5
+        with Client(api_key="dummy", timeout=(3.0, 10.0)) as client:
+            assert client.timeout == (3.0, 10.0)
+
+    @pytest.mark.parametrize("max_retries", [0, 1, 10], ids=["disabled", "one", "many"])
+    def test_init_accepts_custom_max_retries(self, max_retries):
+        with Client(api_key="dummy", max_retries=max_retries) as client:
+            assert retries_of(client).total == max_retries
+
+    def test_init_mounts_a_retry_policy_that_matches_the_documented_behaviour(self):
+        """Asserted here because the effect is otherwise only visible in wall-clock time."""
+        with Client(api_key="dummy") as client:
+            retry = retries_of(client)
+
+            assert set(retry.status_forcelist) == {429, 500, 502, 503, 504}
+            # 404 means the query matched no data, so another attempt only waits to be told
+            # the same thing.
+            assert 404 not in retry.status_forcelist
+            assert retry.backoff_factor > 0
+            # A `Retry-After` from the API wins over the computed backoff.
+            assert retry.respect_retry_after_header is True
+            # See `test__get_maps_an_exhausted_retry_sequence_to_the_status_it_ended_on`.
+            assert retry.raise_on_status is False
 
     @pytest.mark.parametrize("api_key", ["", None], ids=["empty string", "None"])
     def test_init_rejects_an_empty_api_key(self, api_key):
         """`None` covers `Client(os.getenv("TYPO"))`, which would otherwise only fail as a 401."""
         with pytest.raises(ValueError, match="api_key"):
             Client(api_key=api_key)
+
+    @pytest.mark.parametrize("max_retries", [-1, -10])
+    def test_init_rejects_negative_max_retries(self, max_retries):
+        """`Retry(total=-1)` means something else entirely, so it must not be reachable."""
+        with pytest.raises(ValueError, match="max_retries"):
+            Client(api_key="dummy", max_retries=max_retries)
+
+    def test_close_is_idempotent(self):
+        """Calling `close` and then leaving a `with` block must not be an error."""
+        client = Client(api_key="dummy")
+
+        client.close()
+        client.close()
+
+    def test_used_as_a_context_manager_it_yields_itself_and_closes_on_exit(self, mock_api, monkeypatch):
+        """Spied rather than observed: `Session.close` empties its connection pools without
+        leaving anything on the session to assert against.
+        """
+        mock_api.get(f"{BASE_URL}TEST001", json=DUMMY_RESPONSE)
+        client = Client(api_key=API_KEY)
+        closed: list[bool] = []
+        monkeypatch.setattr(client._session, "close", lambda: closed.append(True))
+
+        with client as entered:
+            assert entered is client
+            assert entered._get("TEST001") == DUMMY_RESPONSE
+            assert closed == []
+
+        assert closed == [True]
 
     def test__get(self, mock_api, client):
         expected = {"status": "OK", "data": [{"test": "value"}]}
@@ -202,6 +267,67 @@ class TestClient:
 
         with pytest.raises(ReinfolibError):
             client._get("TEST999")
+
+    def test__get_goes_through_the_session(self, mock_api, client, monkeypatch):
+        """Connection reuse leaves no trace in a response, so guard the call path instead.
+
+        Going back to the module-level `requests.get` would open a fresh connection for
+        every tile and still pass every other test in this file.
+        """
+
+        def fail(*args: object, **kwargs: object) -> None:
+            raise AssertionError("requests.get was called instead of the client's session")
+
+        monkeypatch.setattr(requests, "get", fail)
+        mock_api.get(f"{BASE_URL}TEST001", json=DUMMY_RESPONSE)
+
+        assert client._get("TEST001") == DUMMY_RESPONSE
+
+    def test__get_retries_a_throttled_request(self, mock_api):
+        """Being throttled is expected rather than exceptional: the API sets no explicit
+        request ceiling and asks that calls be spaced out.
+        """
+        mock_api.get(f"{BASE_URL}TEST001", **THROTTLED)
+        mock_api.get(f"{BASE_URL}TEST001", json=DUMMY_RESPONSE)
+
+        with Client(api_key=API_KEY, max_retries=1) as client:
+            assert client._get("TEST001") == DUMMY_RESPONSE
+
+        assert len(mock_api.calls) == 2
+
+    def test__get_maps_an_exhausted_retry_sequence_to_the_status_it_ended_on(self, mock_api):
+        """The reason `raise_on_status` is False.
+
+        Left at the urllib3 default, an exhausted sequence raises inside urllib3, requests
+        wraps that in `RetryError`, and the handler in `_get` would translate it to
+        `TransportError` -- turning a request that was throttled all the way to the last
+        attempt into something indistinguishable from a connection failure.
+        """
+        mock_api.get(f"{BASE_URL}TEST001", **THROTTLED)
+        mock_api.get(f"{BASE_URL}TEST001", **THROTTLED)
+
+        with Client(api_key=API_KEY, max_retries=1) as client, pytest.raises(RateLimitError) as exc_info:
+            client._get("TEST001")
+
+        assert exc_info.value.status_code == 429
+        assert len(mock_api.calls) == 2
+
+    def test__get_does_not_retry_a_query_that_matched_no_data(self, mock_api):
+        """404 is a normal answer here, so retrying it only delays the same result."""
+        mock_api.get(f"{BASE_URL}TEST001", json={"message": "検索結果がありません。"}, status=404)
+
+        with Client(api_key=API_KEY) as client, pytest.raises(NoResultsError):
+            client._get("TEST001")
+
+        assert len(mock_api.calls) == 1
+
+    def test__get_makes_a_single_attempt_when_retries_are_disabled(self, mock_api):
+        mock_api.get(f"{BASE_URL}TEST001", **THROTTLED)
+
+        with Client(api_key=API_KEY, max_retries=0) as client, pytest.raises(RateLimitError):
+            client._get("TEST001")
+
+        assert len(mock_api.calls) == 1
 
     @pytest.mark.parametrize(
         "case",

--- a/uv.lock
+++ b/uv.lock
@@ -198,6 +198,7 @@ name = "pyreinfolib"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },
+    { name = "urllib3" },
 ]
 
 [package.dev-dependencies]
@@ -209,7 +210,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests" }]
+requires-dist = [
+    { name = "requests" },
+    { name = "urllib3", specifier = ">=1.26" },
+]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Every call opened a new connection. Walking a tile grid means one TLS handshake per tile, and being throttled ended the call rather than pausing it. `Client` now owns a `requests.Session` with a retry policy mounted on it, plus `close()` and context manager support.

```python
with Client(api_key=...) as client:
    client.get_municipalities(area="13")
```

The API key moves onto the session headers, so it is set once rather than per request.

### What is retried

429, 500, 502, 503 and 504. Being throttled is an expected answer rather than a fault: the API publishes no request ceiling and instead asks that calls be spaced out (section 3, Q.3 of the manual).

404 is deliberately excluded. It means the query matched no data, so another attempt only waits to be told the same thing.

`max_retries` defaults to 3 and can be set to 0. Waits grow exponentially and a `Retry-After` from the API takes precedence. `timeout` bounds each attempt, not the sequence, which the docstring now says.

### raise_on_status has to be False

Left at urllib3's default, an exhausted sequence raises inside urllib3, requests wraps that in `RetryError`, and the handler in `_get` translates it to `TransportError`. A request throttled all the way to the last attempt would then be indistinguishable from a connection failure, silently undoing the `RateLimitError` mapping added in #36.

Confirmed against a real server rather than reasoned about:

| setting | outcome of a persistent 429 |
| --- | --- |
| `raise_on_status=True` | `RetryError` → `TransportError` |
| `raise_on_status=False` | 429 response → `RateLimitError` |

### No logging was added

The plan had been to log retries, on the grounds that a retry is swallowed internally and is otherwise invisible. urllib3 turns out to log it already, at DEBUG on `urllib3.util.retry`. Adding another record would duplicate it, so nothing was added.

### The adapter is mounted on http:// as well

The API is https only, but `base_url` is a public attribute, so pointing a client at a local double over http is possible. Retrying is a property of the client rather than of the scheme it happens to be talking over, and having it silently not apply would be a surprise.

### urllib3 becomes a declared dependency

`urllib3.util.Retry` is imported directly, and until now urllib3 arrived only as a transitive dependency of requests. `requests.adapters.Retry` is the same object but is an incidental import in requests rather than part of its public API, so relying on it is the more fragile option.

The `>=1.26` floor is measured, not guessed: the suite passes in full against urllib3 1.26.20 in an isolated environment as well as against 2.7.0. No upper bound, since requests already caps it below 3 and upper bounds in a library obstruct downstream resolution. `uv.lock` is regenerated, so `uv sync --locked` still succeeds.

### Verification

`responses` emulates urllib3's retries itself and never sleeps, so the unit tests can assert attempt counts and the exception mapping but not the transport path or the backoff. Those were checked separately, driving the shipped client against a local HTTP server:

| scenario | result |
| --- | --- |
| 429 then 200 | 2 attempts, succeeded |
| 500, 503, then 200 | 3 attempts, succeeded, 2s of waiting |
| persistent 429, `max_retries=1` | `RateLimitError`, not `TransportError` |
| persistent 429, `max_retries=0` | 1 attempt |
| 404 | 1 attempt, `NoResultsError` |
| five consecutive calls | 5 requests over 1 connection |
| persistent 429, default `max_retries=3` | 4 attempts, 6.0s measured (waits of 0, 2, 4) |

Connection reuse is the point of the change, so it is measured from the pool statistics rather than inferred.

`ruff`, `mypy` and 66 tests pass with full branch coverage. Thirteen tests are added. One of them monkeypatches `requests.get` to fail, guarding the call path: reverting to the module-level function would open a connection per request and still pass every other test in the file.
