### PR TITLE
ci: type check with ty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,28 @@ jobs:
       - name: Ruff format check
         run: uv run ruff format --check .
 
+  # Kept out of the `test` matrix on purpose. The interpreter ty checks against comes from
+  # `[tool.ty.environment]`, not from the one it runs under, so a matrix would repeat the same
+  # check. The package ships `py.typed`, which makes its annotations part of its public API and
+  # therefore something CI has to hold to.
+  types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Type check
+        run: uv run ty check
+
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,35 @@
 uv sync --locked
 uv run ruff check .
 uv run ruff format --check .
+uv run ty check
 uv run pytest
 ```
 
-CI が実行するのはこの4つです。型情報を同梱しているため（[PEP 561](https://peps.python.org/pep-0561/)）、型注釈は公開APIの一部として扱います。
+CI が実行するのはこの5つです。
+
+## 型チェック
+
+型情報を同梱しているため（[PEP 561](https://peps.python.org/pep-0561/)）、**型注釈は公開APIの一部**です。破ればテストが通っていても利用者が壊れます。
+
+型チェッカーは [ty](https://github.com/astral-sh/ty) です。mypy と Pyrefly と比較して選定し、実際に過去のバグを検出できることを確認した上で採用しています。
+
+`pyproject.toml` で **バージョンを厳密に固定**しています（`ty==0.0.65`）。他の開発依存は下限指定ですが、ty は pre-1.0 で、診断内容を含む破壊的変更が任意の 0.0.x 間で起こりうると公式に明記されています。下限指定にすると、このリポジトリを変更していないのにパッチ更新で CI が赤くなります。更新は Dependabot に提案させて、そのとき差分を読んでください。
+
+### `tests/typing_usage.py`
+
+**`pyreinfolib` だけを検査しても不十分です。** #45 のズームレベルのバグは、パッケージ内部では整合していて実行時テストも全部通る一方、README が書いている `client.get_...(*tile)` と `tiles.covering()` のループが型チェッカーに拒否される状態でした。エラーは呼び出し側にしか現れません。
+
+そのため `tests/typing_usage.py` に**利用者が書くとおりのコード**を置いて検査対象にしています。テストモジュールではなく、実行もされません。README が推奨する書き方を追加したら、ここにも足してください。ここが通らなくなったらドキュメントが嘘をついています。
+
+拒否されるべきものは `# ty: ignore[...]` を付けて記録しています。`ty check` は何も抑制しなかった ignore を報告し、warning でも実行が失敗するため、**拒否されなくなったら CI が落ちます**。
+
+```python
+# 2つのコード表は交換可能ではない
+client.get_real_estate_prices(
+    year=2024,
+    price_classification=LandPriceClassification.LAND_PRICE_PUBLIC_NOTICE,  # ty: ignore[invalid-argument-type]
+)
+```
 
 ## プルリクエスト
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,11 @@ dev = [
     "pytest-cov>=6.3.0",
     "responses>=0.25.8",
     "ruff>=0.12.12",
+    # Pinned exactly, unlike the others. ty is pre-1.0 and its own documentation states that
+    # breaking changes, diagnostics included, can land between any two 0.0.x releases. A lower
+    # bound would let a patch update turn CI red without a change to this repository.
+    # Dependabot proposes the bump; the diff gets read at that point.
+    "ty==0.0.65",
 ]
 
 [tool.ruff]
@@ -78,3 +83,8 @@ line-ending = "auto"
 
 [tool.pytest.ini_options]
 addopts = "-v --cov=pyreinfolib --cov-branch"
+
+[tool.ty.environment]
+# The floor this package supports. Without it ty checks against whichever interpreter it
+# happens to run under, which would hide a 3.11 problem when run on 3.12.
+python-version = "3.11"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,13 @@
+"""Helpers shared between the test modules. Not a test module itself."""
+
+import requests
+
+
+def params_of(request: requests.PreparedRequest) -> dict[str, str]:
+    """The query parameters `responses` recorded for a request.
+
+    `responses` attaches `params` to the prepared request at runtime, so it is absent from
+    requests' type stubs and has to be reached without the attribute syntax. Kept in one
+    place so the reason is written down once.
+    """
+    return getattr(request, "params")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,6 +5,8 @@ from typing import Any
 import pytest
 import requests
 import responses
+from helpers import params_of
+from requests.adapters import HTTPAdapter
 from urllib3.util import Retry
 
 from pyreinfolib import Client
@@ -72,6 +74,9 @@ def client():
 def retries_of(client: Client) -> Retry:
     """The retry policy the client actually mounted, as the transport sees it."""
     adapter = client._session.get_adapter(BASE_URL)
+    # `get_adapter` is typed as returning the `BaseAdapter` interface, which carries no
+    # retry policy. Narrowing to the concrete adapter is what makes `max_retries` reachable.
+    assert isinstance(adapter, HTTPAdapter)
     assert isinstance(adapter.max_retries, Retry)
     return adapter.max_retries
 
@@ -85,9 +90,10 @@ def assert_request(mock_api: responses.RequestsMock, method: Callable, endpoint:
 
     assert len(mock_api.calls) == 1
     request = mock_api.calls[0].request
+    assert request.url is not None
     assert request.url.split("?")[0] == url
     assert request.headers["Ocp-Apim-Subscription-Key"] == API_KEY
-    assert request.params == case.expected_params
+    assert params_of(request) == case.expected_params
 
 
 class TestClient:
@@ -633,7 +639,7 @@ class TestClient:
 
         getattr(client, method_name)(**args)
 
-        params = mock_api.calls[0].request.params
+        params = params_of(mock_api.calls[0].request)
         assert params["response_format"] == "geojson"
         assert params["z"] == str(args["z"])
         assert params["x"] == str(args["x"])

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -2,6 +2,7 @@ from collections.abc import Iterator
 
 import pytest
 import responses
+from helpers import params_of
 
 from pyreinfolib import Client
 from pyreinfolib.tiles import MAX_LATITUDE, Bounds, Tile, bounds, containing, count_covering, covering
@@ -233,7 +234,7 @@ class TestTile:
             with Client(api_key="dummy") as client:
                 client.get_number_of_passengers_per_station(*tile)
 
-            params = mock_api.calls[0].request.params
+            params = params_of(mock_api.calls[0].request)
 
         assert params["z"] == str(tile.z)
         assert params["x"] == str(tile.x)

--- a/tests/typing_usage.py
+++ b/tests/typing_usage.py
@@ -1,0 +1,170 @@
+"""Caller-side usage, kept here to be type checked. Not a test module and never executed.
+
+Checking `pyreinfolib` on its own is not enough. The zoom level defect fixed in #45 left the
+package internally consistent and every runtime test passing, while the two idioms the README
+documents -- `client.get_...(*tile)` and a loop over `tiles.covering` -- were rejected by any
+type checker the moment a user ran one. The error only appears at the call site, so a call
+site has to be checked.
+
+Write what the README tells a reader to write. If something here stops type checking, the
+documentation has started lying.
+
+Runtime behaviour is covered by `test_client.py` and `test_tiles.py`; nothing here runs, and
+no API key or network is involved.
+"""
+
+from pyreinfolib import APIError, Client, NoResultsError, RateLimitError, ReinfolibError, tiles
+from pyreinfolib.enums import LandPriceClassification, LandTypeCode, PriceClassification, UseDivision
+
+API_KEY = "not-a-real-key"
+
+
+def construction() -> None:
+    Client(api_key=API_KEY)
+    Client(api_key=API_KEY, timeout=5)
+    Client(api_key=API_KEY, timeout=(3.0, 10.0))
+    Client(api_key=API_KEY, max_retries=0)
+
+    with Client(api_key=API_KEY) as client:
+        client.close()
+
+
+def non_tile_endpoints(client: Client) -> None:
+    client.get_real_estate_prices(year=2024)
+    client.get_real_estate_prices(
+        year=2024,
+        quarter=1,
+        price_classification=PriceClassification.REAL_ESTATE_TRANSACTION_PRICE,
+        area="13",
+        city="13109",
+        station="003785",
+        language="ja",
+    )
+    client.get_municipalities(area="13")
+    client.get_municipalities(area="13", language="en")
+    client.get_appraisal_reports(year=2024, area="13", division=UseDivision.INDUSTRIAL_LAND)
+
+
+def tile_endpoints_from_a_point(client: Client) -> None:
+    """The idiom that #45 fixed. `Tile.z` is an `int`, so a `Literal` parameter rejects it."""
+    tile = tiles.containing(lon=139.7016, lat=35.6580, z=15)
+
+    client.get_number_of_passengers_per_station(*tile)
+    client.get_number_of_passengers_per_station(z=tile.z, x=tile.x, y=tile.y)
+    client.get_real_estate_prices_point(*tile, period_from=20241, period_to=20242)
+    client.get_land_price_public_notices_and_surveys_point(*tile, year=2020)
+
+
+def tile_endpoints_over_an_extent(client: Client) -> None:
+    """The other idiom #45 fixed, and the one that matters for anything larger than a point."""
+    box = {"west": 139.665, "south": 35.640, "east": 139.724, "north": 35.679}
+
+    count: int = tiles.count_covering(**box, z=15)
+    assert count > 0
+
+    for tile in tiles.covering(**box, z=15):
+        client.get_real_estate_prices_point(
+            *tile,
+            period_from=20241,
+            period_to=20242,
+            price_classification=PriceClassification.CONTRACT_PRICE,
+        )
+
+
+def zoom_levels_from_elsewhere(client: Client) -> None:
+    """A level that arrives computed rather than written out. The `Literal` rejected all of these."""
+    zoom = 14
+    client.get_number_of_passengers_per_station(z=zoom, x=1819, y=806)
+
+    for z in range(11, 16):
+        client.get_number_of_passengers_per_station(z=z, x=1819, y=806)
+
+    client.get_number_of_passengers_per_station(z=int("13"), x=1819, y=806)
+
+
+def code_sequences(client: Client) -> None:
+    """A single code needs no list, and a sequence of them is accepted."""
+    client.get_real_estate_prices_point(
+        z=15,
+        x=29099,
+        y=12905,
+        period_from=20241,
+        period_to=20242,
+        land_type_code=LandTypeCode.LAND,
+    )
+    client.get_real_estate_prices_point(
+        z=15,
+        x=29099,
+        y=12905,
+        period_from=20241,
+        period_to=20242,
+        land_type_code=[LandTypeCode.LAND, LandTypeCode.FOREST_LAND],
+    )
+    client.get_land_price_public_notices_and_surveys_point(
+        z=13,
+        x=7312,
+        y=3008,
+        year=2020,
+        price_classification=LandPriceClassification.LAND_PRICE_PUBLIC_NOTICE,
+        use_category_code=[UseDivision.RESIDENTIAL_LAND, UseDivision.COMMERCIAL_LAND],
+    )
+
+
+def error_handling(client: Client) -> None:
+    """Catching these must not require importing `requests`, which is the point of #36."""
+    try:
+        client.get_real_estate_prices(year=2024, city="13109")
+    except NoResultsError:
+        pass
+    except RateLimitError as e:
+        _: int = e.status_code
+    except APIError as e:
+        print(e.status_code, e.response_body, e.url)
+    except ReinfolibError:
+        pass
+
+
+def tile_geometry() -> None:
+    tile = tiles.containing(lon=139.7016, lat=35.6580, z=15)
+    extent = tiles.bounds(tile)
+
+    west: float = extent.west
+    south: float = extent.south
+    east: float = extent.east
+    north: float = extent.north
+    assert west <= east and south <= north
+
+    z: int = tile.z
+    x: int = tile.x
+    y: int = tile.y
+    assert (z, x, y) == tuple(tile)
+
+
+def rejected_by_the_checker(client: Client) -> None:
+    """Cases that must stay rejected.
+
+    `ty check` reports an ignore directive that suppressed nothing, and a warning is enough to
+    fail the run, so each of these fails the build if the rejection ever stops happening.
+    """
+    # The two price classification tables are not interchangeable.
+    client.get_land_price_public_notices_and_surveys_point(
+        z=13,
+        x=7312,
+        y=3008,
+        year=2020,
+        price_classification=PriceClassification.CONTRACT_PRICE,  # ty: ignore[invalid-argument-type]
+    )
+    client.get_real_estate_prices(
+        year=2024,
+        price_classification=LandPriceClassification.LAND_PRICE_PUBLIC_NOTICE,  # ty: ignore[invalid-argument-type]
+    )
+
+    # A bare code string is no longer accepted for a parameter that has an enum.
+    client.get_real_estate_prices(year=2024, price_classification="01")  # ty: ignore[invalid-argument-type]
+
+    # The point helpers are keyword only, so a longitude and a latitude cannot be swapped by
+    # passing them positionally.
+    tiles.containing(139.7016, 35.6580, 15)  # ty: ignore[too-many-positional-arguments, missing-argument]
+
+    # An API key is required.
+    Client()  # ty: ignore[missing-argument]

--- a/uv.lock
+++ b/uv.lock
@@ -242,6 +242,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "responses" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -256,6 +257,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.3.0" },
     { name = "responses", specifier = ">=0.25.8" },
     { name = "ruff", specifier = ">=0.12.12" },
+    { name = "ty", specifier = "==0.0.65" },
 ]
 
 [[package]]
@@ -449,6 +451,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.65"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cf561927e8e9ab5c1892a833b664aa9cd6f051a75f6280c66d8047246bda/ty-0.0.65.tar.gz", hash = "sha256:b7134bffcc00b715fa8291e84d845782ced810a998dc1f7f11d71c85c4046325", size = 6460098, upload-time = "2026-07-29T18:31:03.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/4e/71e2d325d2b53a1afad81624ad076b2ede413213fc4a18cb05b78c568571/ty-0.0.65-py3-none-linux_armv6l.whl", hash = "sha256:dc556c9f05408bef4c4ef02b2cc382e4e5f797b4b20d64410289848f0d76705f", size = 12298466, upload-time = "2026-07-29T18:30:12.744Z" },
+    { url = "https://files.pythonhosted.org/packages/57/77/fec8f29647c55794efa430a7f365e44f5ce7ffb6459d9445a87fac569bec/ty-0.0.65-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:29d2e0d34cc0a28a17ef0cf81135c5ebabc3562131f9079138ba5e7bae0f56bd", size = 11942421, upload-time = "2026-07-29T18:30:16.076Z" },
+    { url = "https://files.pythonhosted.org/packages/13/09/7f3766aef9dc627e2698cf4e3e59cf53389dcae3812040d33c1aa931230f/ty-0.0.65-py3-none-macosx_11_0_arm64.whl", hash = "sha256:685f49a9312bbf69d5b65bbb66384fed1f927403ea030c217b9289092d7e46c4", size = 11451922, upload-time = "2026-07-29T18:30:19.155Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7b/1a77cd50e0befb50f55b8bf9bd3ed3eddf184bf28c61b56727039e0774fc/ty-0.0.65-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f564b5ebe78e2f3a8e7b8eacb1292eb88b7c0f3c8630671cfca31abc0709cd9", size = 11994999, upload-time = "2026-07-29T18:30:22.315Z" },
+    { url = "https://files.pythonhosted.org/packages/63/7b/feda16f3a4a0a99be27431e0c9598eeeec0db1eb2fec9a15976698209418/ty-0.0.65-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c983e156fe9e113fb56389e13d327b6b8549fe866de9b269684723a88e9b732d", size = 12090662, upload-time = "2026-07-29T18:30:24.93Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/3e/3f69bf9c9307dbdc0771719f65ce5b556e7bdeeaccbdd599d4f57866d801/ty-0.0.65-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e3663b7396e8b1a9954e20e732de7ccb0192bf4118473069b4945920d6923921", size = 12822094, upload-time = "2026-07-29T18:30:28.012Z" },
+    { url = "https://files.pythonhosted.org/packages/90/38/8fa791b3bb503ee2b46ad81690cd1bdd54519582df6d805cee57fe143e85/ty-0.0.65-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:306ed01f29d6e108e98feb233dbbf5878a027603b71bd3743b343977933a9f16", size = 13357833, upload-time = "2026-07-29T18:30:31.122Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/73/4dda396a201e1dd0ed3594a9b48e559cb41c4bc048c6cd4c4d1b39eb4313/ty-0.0.65-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28bcfc8898c94f079a9100e684bcf312b6a64ad3a7d4ebb35a4591546030a2cd", size = 12977303, upload-time = "2026-07-29T18:30:33.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/26/c250c2c569adc53a8591716641388397bcb2a442e4a30b952ae81b50c0e0/ty-0.0.65-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a75bd0c245c38802a8f488378e74f92feb7dd33db7d63fbdd6fdf82791ba730", size = 12579338, upload-time = "2026-07-29T18:30:37.199Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/94/4a5647d44753ca218fc930d7e4d9bf468d0ed4a0ad4b3d57588bc1bbacf7/ty-0.0.65-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9e5e1bdea9662d2b5312b4e99f319f4e6e2ea427511b5fbc546141b79ec53f76", size = 12957731, upload-time = "2026-07-29T18:30:39.937Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b6/1e22fa11a1e0dfb20b1c7f3cbfd8170273aada2a82f9ecd3055275370c44/ty-0.0.65-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:03a88493d4842889f65280ae241e06b399d57eb3c63571054cad21a4c33b3b69", size = 11938625, upload-time = "2026-07-29T18:30:42.603Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0a/fe5f22ef62b193201bc5566762e22049762cd485bfafb5095a7050760054/ty-0.0.65-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:600b8bf6f4940cf7ffb2f43d3716faaf38dcb97cd8617c55771451bc0276408f", size = 12105592, upload-time = "2026-07-29T18:30:45.419Z" },
+    { url = "https://files.pythonhosted.org/packages/76/fd/922b3a6e9d697452cdbb4b7e3f636868add5ec652154518a736e4364f3b7/ty-0.0.65-py3-none-musllinux_1_2_i686.whl", hash = "sha256:0c28007bc79d648c1ddaf1e65885d07baec48eb87240da442f608e4107c1b7d8", size = 12387335, upload-time = "2026-07-29T18:30:48.405Z" },
+    { url = "https://files.pythonhosted.org/packages/77/22/a1a08ebc84c083db2fb55e3b5cd186db0c067692f4921146f601360231e2/ty-0.0.65-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:c852da96091ad22361e6586b7c7ba98e1334dcd4d8ffb67e47f4fb673de33f77", size = 12682710, upload-time = "2026-07-29T18:30:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/81/14/eaaa410a25bbdea19722109b5422380a0e211b3afcf3071d15953ddbd5db/ty-0.0.65-py3-none-win32.whl", hash = "sha256:cf529d538f1403b14b0511e6ec3cdb95d3d974adabf24cc76cedc533368c3edc", size = 11692341, upload-time = "2026-07-29T18:30:54.35Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/0f/6d48f206dce9d7e53fe3b5ea0f0ab5800dd9d2365b2b48f736783436c43f/ty-0.0.65-py3-none-win_amd64.whl", hash = "sha256:234a321e33c7cbbfbd67bfa0b01b685dd9c21f1841781a21e5ca1fa0b25f1d5d", size = 12729355, upload-time = "2026-07-29T18:30:57.275Z" },
+    { url = "https://files.pythonhosted.org/packages/96/aa/7446f7725e303cf78e058c893af1f0552b9451895454908706f4c6c3494b/ty-0.0.65-py3-none-win_arm64.whl", hash = "sha256:b9424be1ec56d93ff18609fb1c0a0a2283fe1282cd6d1c7604f97d73b94d61f2", size = 12051375, upload-time = "2026-07-29T18:31:00.579Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
CI did not check types. The package ships `py.typed`, so its annotations are public API. #45 was the cost: the package stayed internally consistent, every test passed, and both idioms the README documents were rejected by any type checker a user ran.

## Changes

- `types` job in `ci.yml`, running [ty](https://github.com/astral-sh/ty)
- `ty==0.0.65` in dev dependencies
- `[tool.ty.environment]` sets `python-version = "3.11"`, the supported floor
- `tests/typing_usage.py`: caller-side code, type checked, never executed
- `tests/helpers.py`: `params_of`, shared by both test modules
- Three typing gaps fixed in the tests
- CONTRIBUTING.md: the tool choice, the pin, and how to extend the usage file

## Notes

- Checking `pyreinfolib` alone would not have caught #45. Every checker reports the package clean, before the fix and after. The error appears only at the call site.
- `tests/typing_usage.py` is written the way the README tells a reader to write. If it stops type checking, the README is wrong.
- Rejections that must stay rejected are recorded there with `# ty: ignore[...]`. ty reports an ignore directive that suppressed nothing, and a warning fails the run.
- `ty` is pinned exactly, unlike the other dev dependencies. It is pre-1.0 and documents that breaking changes, diagnostics included, can land between any two 0.0.x releases.
- The `types` job is not in the `test` matrix. The checked interpreter comes from configuration, not from the runner.
- The three test gaps were reported identically by mypy, ty and Pyrefly.
