### PR TITLE
fix!: refuse a blank argument instead of treating it as omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ from pyreinfolib import Client
 client = Client(api_key=os.environ["REINFOLIB_API_KEY"])
 ```
 
+引数を省略する、または `None` を渡すと、その絞り込みを行いません。`get_real_estate_prices(year=2024)` は全国が対象になります。
+
+空文字を渡した場合は `ValueError` になります。省略と同じ扱いにはしません。`city=""` を絞り込みのつもりで渡したときに、黙って全国が返ることを避けるためです。フォームや環境変数の値をそのまま渡す場合は `city=value or None` としてください。同様に、コードのリストが空（`land_type_code=[]`）の場合も `ValueError` です。絞り込んだ結果が0件になったことは、全種類を要求することとは違うためです。
+
 `Client` はコネクションを再利用します。タイル系APIを複数タイル分呼ぶような使い方では、TLSハンドシェイクが1回で済みます。使い終わったら `close()` するか、`with` を使ってください。
 
 ```python

--- a/pyreinfolib/client.py
+++ b/pyreinfolib/client.py
@@ -52,7 +52,8 @@ def _join_codes(codes: Sequence[str] | str | None) -> str | None:
     because `",".join()` treats the string as a sequence of characters.
 
     Passes `None` through so that an omitted argument can be handed to `_compact` like any
-    other. An empty sequence becomes an empty string, which `_compact` then drops.
+    other. An empty sequence becomes an empty string, which `_compact` then refuses: a caller
+    whose list of codes filtered down to nothing is not asking for every code.
     """
     if codes is None:
         return None
@@ -62,16 +63,27 @@ def _join_codes(codes: Sequence[str] | str | None) -> str | None:
 
 
 def _compact(params: dict[str, Any]) -> dict[str, Any]:
-    """Drop the entries the API should not receive at all.
+    """Drop the arguments the caller left out, and refuse the ones left blank.
 
-    `None` marks an argument the caller left out. An empty string is dropped too, which
-    keeps `city=""` out of the query the way the per-argument `if` checks used to.
+    `None` is how an argument is omitted, and omitting a filter is a supported request: the
+    only required argument of most endpoints is the period, so leaving `city` out asks for the
+    whole country on purpose.
 
-    Deliberately not a truthiness test. `x=0` is already a valid tile coordinate, and a
-    future parameter whose valid values include `0` would otherwise vanish from the request
-    with nothing to show why.
+    A blank value is not another way to say that. It used to be dropped as though it were
+    `None`, which meant `city=""` quietly widened a query to the whole country, a blank
+    required argument disappeared from the request altogether, and an empty list of codes read
+    as no filter at all. None of the three announced itself.
+
+    Values are compared against `""` rather than tested for truthiness. `x=0` is a valid tile
+    coordinate, and a future parameter whose valid values include `0` would otherwise vanish
+    from the request with nothing to show why.
     """
-    return {key: value for key, value in params.items() if value is not None and value != ""}
+    blank = sorted(key for key, value in params.items() if value == "")
+    if blank:
+        listed = ", ".join(blank)
+        raise ValueError(f"Blank value for {listed}. Leave the argument out, or pass `None`, to omit it.")
+
+    return {key: value for key, value in params.items() if value is not None}
 
 
 class Client:
@@ -248,6 +260,7 @@ class Client:
         :param station: Station code. See https://nlftp.mlit.go.jp/ksj/gml/datalist/KsjTmplt-N02-v3_1.html
         :param language: `ja` or `en`. If not specified, `ja`.
         :return: Real estate prices.
+        :raises ValueError: If an argument is blank. Leave it out instead, to omit it.
         :raises NoResultsError: If no transaction matches the given period and area.
         """
         params = _compact(
@@ -270,6 +283,7 @@ class Client:
         :param area: Prefecture code. See https://nlftp.mlit.go.jp/ksj/gml/codelist/PrefCd.html
         :param language: `ja` or `en`. If not specified, `ja`.
         :return: Municipality list.
+        :raises ValueError: If `area` is blank.
         :raises NoResultsError: If the prefecture code matches no municipality.
         """
         params = _compact({"area": area, "language": language})
@@ -283,9 +297,12 @@ class Client:
         :param area: Prefecture code.
         :param division: Use division.
         :return: Real estate appraisal reports.
+        :raises ValueError: If `area` is blank.
         :raises NoResultsError: If no appraisal report matches the given year and area.
         """
-        params: dict[str, Any] = {"year": year, "area": area, "division": division}
+        # Through `_compact` although nothing here is optional, so that a blank `area` is
+        # refused rather than sent as `area=`, which is what this method did on its own.
+        params = _compact({"year": year, "area": area, "division": division})
 
         return self._get("XCT001", params)
 
@@ -311,7 +328,7 @@ class Client:
         :param land_type_code: One land type code, or a sequence of them.
           See https://www.reinfolib.mlit.go.jp/help/apiManual/#titleApi7
         :return: Real estate prices point. (Response format: GeoJson)
-        :raises ValueError: If `z` is not between 11 and 15.
+        :raises ValueError: If `z` is not between 11 and 15, or `land_type_code` is empty.
         """
         return self._get_tile(
             "XPT001",
@@ -350,7 +367,7 @@ class Client:
           See https://www.reinfolib.mlit.go.jp/help/apiManual/#titleApi8
         :return: land price public notices (standard land prices) and
         prefectural land price surveys (benchmark land prices) point. (Response format: GeoJson)
-        :raises ValueError: If `z` is not between 13 and 15.
+        :raises ValueError: If `z` is not between 13 and 15, or `use_category_code` is empty.
         """
         return self._get_tile(
             "XPT002",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -375,8 +375,10 @@ class TestClient:
                 expected_params={"year": "2025"},
             ),
             RequestCase(
-                id="omitted and empty optional params are absent from the query",
-                args={"year": 2025, "price_classification": None, "quarter": None, "city": ""},
+                # Omitting the filters is a supported request, not a mistake: `year` is the
+                # only required argument, so this asks for the whole country deliberately.
+                id="omitted optional params are absent from the query",
+                args={"year": 2025, "price_classification": None, "quarter": None, "city": None},
                 expected_params={"year": "2025"},
             ),
         ],
@@ -511,16 +513,14 @@ class TestClient:
                 },
             ),
             RequestCase(
-                # `",".join([])` is an empty string, which has to be dropped rather than
-                # sent as `landTypeCode=`.
-                id="an empty land type sequence is omitted",
+                id="land types omitted entirely",
                 args={
                     "z": 15,
                     "x": 1819,
                     "y": 806,
                     "period_from": 20241,
                     "period_to": 20241,
-                    "land_type_code": [],
+                    "land_type_code": None,
                 },
                 expected_params={
                     "response_format": "geojson",
@@ -739,3 +739,84 @@ class TestEnums:
         assert price_codes == {"01", "02"}
         assert land_price_codes == {"0", "1"}
         assert not price_codes & land_price_codes
+
+
+class TestBlankArguments:
+    """A blank argument used to be treated as an omitted one, in three different ways.
+
+    `city=""` widened a query to the whole country, a blank required argument disappeared from
+    the request, and `land_type_code=[]` read as no filter. None of the three said anything, so
+    a caller who thought they had filtered got a wider answer and no indication of it.
+
+    Omitting a filter is still supported and still means the whole country. It is spelled by
+    leaving the argument out, or passing `None`, which `test_get_real_estate_prices` covers.
+    """
+
+    @pytest.mark.parametrize("argument", ["area", "city", "station", "language"])
+    def test_a_blank_optional_filter_is_refused(self, mock_api, client, argument):
+        """Nothing is registered on `mock_api`, so a blank that slipped through would fail as
+        an unmatched request rather than quietly fetching the whole country.
+        """
+        with pytest.raises(ValueError, match=argument):
+            client.get_real_estate_prices(year=2024, **{argument: ""})
+
+    @pytest.mark.parametrize(
+        ("method_name", "args"),
+        [
+            ("get_real_estate_prices", {"year": 2024, "area": ""}),
+            ("get_municipalities", {"area": ""}),
+            ("get_appraisal_reports", {"year": 2024, "area": "", "division": UseDivision.INDUSTRIAL_LAND}),
+        ],
+        ids=["XIT001", "XIT002", "XCT001"],
+    )
+    def test_a_blank_area_is_refused_by_every_method_that_takes_one(self, mock_api, client, method_name, args):
+        """Uniform across the three, which it was not.
+
+        `get_municipalities` dropped a blank `area` even though it is required, producing a
+        request with no query string at all. `get_appraisal_reports` did not go through
+        `_compact` and sent `area=` instead. Same argument, same blank, two behaviours.
+        """
+        with pytest.raises(ValueError, match="area"):
+            getattr(client, method_name)(**args)
+
+    @pytest.mark.parametrize(
+        ("method_name", "args", "expected"),
+        [
+            (
+                "get_real_estate_prices_point",
+                {"z": 15, "x": 1819, "y": 806, "period_from": 20241, "period_to": 20241, "land_type_code": []},
+                "landTypeCode",
+            ),
+            (
+                "get_land_price_public_notices_and_surveys_point",
+                {"z": 13, "x": 7312, "y": 3008, "year": 2020, "use_category_code": []},
+                "useCategoryCode",
+            ),
+        ],
+        ids=["land_type_code", "use_category_code"],
+    )
+    def test_an_empty_sequence_of_codes_is_refused(self, mock_api, client, method_name, args, expected):
+        """A list that filtered down to nothing is not a request for every code."""
+        with pytest.raises(ValueError, match=expected):
+            getattr(client, method_name)(**args)
+
+    def test_the_refusal_names_every_blank_argument_and_says_what_to_do(self, mock_api, client):
+        """Naming one of three would send the caller back for another round."""
+        with pytest.raises(ValueError) as exc_info:
+            client.get_real_estate_prices(year=2024, area="", city="", station="")
+
+        message = str(exc_info.value)
+        assert "area" in message
+        assert "city" in message
+        assert "station" in message
+        assert "None" in message
+
+    def test_zero_is_not_treated_as_blank(self, mock_api, client):
+        """`x=0` is a valid tile coordinate, so the check compares against `""` rather than
+        testing truthiness.
+        """
+        mock_api.get(f"{BASE_URL}XKT015", json=DUMMY_RESPONSE)
+
+        client.get_number_of_passengers_per_station(z=11, x=0, y=0)
+
+        assert params_of(mock_api.calls[0].request)["x"] == "0"


### PR DESCRIPTION
A blank argument was treated as an omitted one, in three different ways and none of them audible. `city=""` widened a query to the whole country. A blank required `area` disappeared from the request, leaving `get_municipalities` with no query string at all. `land_type_code=[]` read as no filter. A caller who thought they had filtered got a wider answer with nothing to indicate it.

`None`, or leaving the argument out, is now the only way to omit one. A blank value raises `ValueError`.

## Changes

- `_compact` refuses `""` rather than dropping it, and names every blank argument in the message
- `get_appraisal_reports` goes through `_compact`, which it did not
- README: how to omit a filter, and `city=value or None` for values that may be blank
- `:raises ValueError:` on the affected methods

## Notes

- No capability is lost. Requesting the whole country is spelled by leaving the filter out, since `year` is the only required argument of `get_real_estate_prices`, and that was already supported and tested.
- `get_appraisal_reports` bypassed `_compact` and sent `area=` where the other two dropped it. The same blank argument behaved two ways, so bringing it in was not separable from the fix.
- Whitespace-only values are left alone. `city=" "` is sent as `city=+` and comes back as `NoResultsError` or an API error, so it is not the silent class of failure this addresses.
- `land_type_code=[]` now raises for the same reason as `city=""`: a list that filtered down to nothing is not a request for every code.

BREAKING CHANGE: a blank string argument now raises `ValueError` instead of being dropped. Pass `None`, or leave the argument out, to omit it; use `city=value or None` for a value that may be blank. An empty sequence of codes raises for the same reason.
