### PR TITLE
feat!: use MLIT current terminology for the land price surveys

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ CI が実行するのはこの5つです。
 # 2つのコード表は交換可能ではない
 client.get_real_estate_prices(
     year=2024,
-    price_classification=LandPriceClassification.LAND_PRICE_PUBLIC_NOTICE,  # ty: ignore[invalid-argument-type]
+    price_classification=LandPriceClassification.LAND_MARKET_VALUE_PUBLICATION,  # ty: ignore[invalid-argument-type]
 )
 ```
 
@@ -83,7 +83,7 @@ API 側が改称したとき、追随すべきかの判断がつきます。
 
 ### 長さは基準にしません
 
-手順の結果が長くても短縮しません。短縮するかを毎回判断すると、判断のぶれが名前のぶれになります。`get_land_price_public_notices_and_surveys_point` は規則を守った結果として正しい名前です。
+手順の結果が長くても短縮しません。短縮するかを毎回判断すると、判断のぶれが名前のぶれになります。`get_land_market_value_publication_and_research_point` は規則を守った結果として正しい名前です。
 
 ### 単数・複数
 
@@ -100,7 +100,7 @@ API 側が改称したとき、追随すべきかの判断がつきます。
 | XIT002 | 都道府県内市区町村一覧取得API | 都道府県内（手順6）、一覧取得 | `get_municipalities` |
 | XCT001 | 鑑定評価書情報API | 情報 | `get_appraisal_reports` |
 | XPT001 | 不動産価格（取引価格・成約価格）情報のポイント (点) API | 括弧（手順3）、情報 | `get_real_estate_prices_point` |
-| XPT002 | 地価公示・地価調査のポイント (点) API | なし | `get_land_price_public_notices_and_surveys_point` |
+| XPT002 | 地価公示・地価調査のポイント (点) API | なし | `get_land_market_value_publication_and_research_point` |
 | XKT015 | 国土数値情報（駅別乗降客数）API | 国土数値情報（手順2） | `get_number_of_passengers_per_station` |
 
 ## enum
@@ -136,8 +136,9 @@ class PriceClassification(StrEnum):
 ### 典拠の優先順位
 
 1. **[日本法令外国語訳データベースシステム](https://www.japaneselawtranslation.go.jp/)**（法務省）。今回必要な語の多くは法令用語で、政府公式訳が条文単位で日英対応しています
-2. **所管省庁の英語版資料**。法令用語でないもの（統計用語、データセット名）
-3. **既にこのライブラリで使っている訳語**。1と2で確認できないもの
+2. **[地価に関する国際的な情報発信の強化に向けた検討業務 調査報告書](https://www.mlit.go.jp/common/000214955.pdf)**（国土交通省 土地・建設産業局、平成24年3月）。地価公示・鑑定評価の語彙について、MLIT が統一的な英訳を提示する目的で作成した用語集です。地価関連語は法令訳DBより詳しく、DBの訳に対する明示的な注記もあります
+3. **所管省庁の英語版資料**。法令用語でないもの（統計用語、データセット名）
+4. **既にこのライブラリで使っている訳語**。1〜3で確認できないもの
 
 ### 確定
 
@@ -153,6 +154,18 @@ class PriceClassification(StrEnum):
 | 市街化区域 | urbanization promotion area | 都市計画法7条 |
 | 市街化調整区域 | urbanization control area | 都市計画法7条 |
 | 地区計画 | district plan | 都市計画法12条の4 |
+| 地価公示 | land market value publication | MLIT 用語集 200, 201（地価公示室 / 地価公示法） |
+| 地価調査 | land market value research | MLIT 用語集 205（地価調査課） |
+| 都道府県地価調査 | prefectural land market value research | MLIT 用語集 259 |
+| 標準地 | standard site | MLIT 用語集 275 |
+| 基準地 | standard site published by the prefectural government | MLIT 用語集 48 |
+| 土地鑑定委員会 | Land Appraisal Committee | [MLIT 英語ページ](https://www.mlit.go.jp/en/totikensangyo/totikensangyo_fr4_000001.html) |
+
+MLIT 用語集は `Land （Market） Value` と括弧付きで記載していますが、識別子に括弧は使えず、[MLIT の英語ページ](https://www.mlit.go.jp/en/totikensangyo/totikensangyo_fr4_000001.html)が括弧なしで運用しているため、括弧を外した形を採用します。
+
+**`public notice` は使いません。** MLIT 用語集 201 に「Public notice という訳もあるようだが、通達と紛らわしい」と、退けた理由が明記されています。英語ページも `Land price public notice system` を「以前の呼称」としています。
+
+**公示と調査は Publication と Research で区別します。** 用語集 259 の 都道府県地価調査 の訳は説明的な文章で、地価公示と同じ "publication" を使っています。そのまま識別子にすると2つのデータセットがほぼ同名になるため、組織名（地価公示室 / 地価調査課）の固有名詞形から採ります。
 
 用途地域の内訳（13種）も同じ典拠から取れます。第一種低層住居専用地域 = category 1 low-rise exclusive residential district、準住居地域 = quasi-residential district、田園住居地域 = countryside residential district、準工業地域 = quasi-industrial district、工業専用地域 = exclusive industrial district、ほか。
 
@@ -171,8 +184,6 @@ class PriceClassification(StrEnum):
 
 | 用語 | 典拠を探す先 | 用途 |
 |---|---|---|
-| 地価公示 | 地価公示法 | XPT002、既存名で `land_price_public_notice` を使用中（未検証） |
-| 都道府県地価調査 | 国土利用計画法施行令 | XPT002、既存名で `prefectural_land_price_survey` を使用中（未検証） |
 | 立地適正化計画 | 都市再生特別措置法 | XKT003 |
 | 災害危険区域 | 建築基準法39条 | XKT016 |
 | 自然公園地域 | 自然公園法 | XKT019 |
@@ -190,5 +201,3 @@ class PriceClassification(StrEnum):
 | 災害履歴 | 国土調査（土地履歴調査） | XST001 |
 
 XKT004〜018 の施設系（小学校区、学校、保育園・幼稚園等、医療機関、福祉施設、図書館、市区町村役場及び集会施設等）は一般語なので法令典拠は不要です。
-
-**地価公示 と 都道府県地価調査 は優先度が高いです。** 既に公開済みのメソッド名と enum メンバー名に使っているため、公式訳が違っていた場合の修正は破壊的変更になります。1.0 到達前に確定させてください。

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ client.get_number_of_passengers_per_station(*tile)
 
 `Tile` は `z, x, y` の順なので、タイル系メソッドにそのまま展開して渡せます。
 
-受け付けるズームレベルはエンドポイントごとに違います（多くは11〜15、`get_land_price_public_notices_and_surveys_point` は13〜15）。範囲外を渡すと、どのエンドポイントが何を期待しているかを含む `ValueError` になります。`tiles` 側はエンドポイントを知らないので、そこでは検証しません。
+受け付けるズームレベルはエンドポイントごとに違います（多くは11〜15、`get_land_market_value_publication_and_research_point` は13〜15）。範囲外を渡すと、どのエンドポイントが何を期待しているかを含む `ValueError` になります。`tiles` 側はエンドポイントを知らないので、そこでは検証しません。
 
 引数はキーワード専用です。GeoJSON や地図系ライブラリは経度を先に置きますが、日本の利用者は緯度経度の順で考えるため、順序を記憶に頼らせない形にしています。
 
@@ -174,7 +174,7 @@ except APIError as e:
 | enum | 対象 | コード |
 |---|---|---|
 | `PriceClassification` | 不動産価格（XIT001、XPT001） | `01` 不動産取引価格情報 / `02` 成約価格情報 |
-| `LandPriceClassification` | 地価公示・地価調査（XPT002） | `0` 地価公示 / `1` 都道府県地価調査 |
+| `LandPriceClassification` | 地価公示・地価調査（XPT002） | `0` 地価公示 = `LAND_MARKET_VALUE_PUBLICATION` / `1` 都道府県地価調査 = `PREFECTURAL_LAND_MARKET_VALUE_RESEARCH` |
 
 別の型にしてあるので、取り違えは型チェックで検出されます。誤ったコードを送った場合、API はエラーではなく絞り込まれた結果や空の結果を返すため、実行時には気づきにくい種類の間違いです。
 

--- a/pyreinfolib/client.py
+++ b/pyreinfolib/client.py
@@ -343,7 +343,7 @@ class Client:
             },
         )
 
-    def get_land_price_public_notices_and_surveys_point(
+    def get_land_market_value_publication_and_research_point(
         self,
         z: int,
         x: int,
@@ -352,8 +352,12 @@ class Client:
         price_classification: enums.LandPriceClassification | None = None,
         use_category_code: Sequence[enums.UseDivision] | enums.UseDivision | None = None,
     ) -> dict[str, Any]:
-        """Get land price public notices (standard land prices) and
-        prefectural land price surveys (benchmark land prices) point.
+        """Get land market value publication (地価公示) and land market value research
+        (地価調査) point.
+
+        Both surveys are published on this endpoint. `price_classification` selects one, or
+        leave it unset for both. The publication values market values of standard sites; the
+        research values the standard sites published by prefectural governments.
         See https://www.reinfolib.mlit.go.jp/help/apiManual/#titleApi8 for details.
         :param z: Zoom level (scale). 13 ~ 15 (detail)
         :param x: x value of tile coordinates.
@@ -361,12 +365,12 @@ class Client:
         :param year: target year.
         :param price_classification: Land price classification. Note that this is
           `LandPriceClassification`, a different code table from the `PriceClassification`
-          the real estate price endpoints take. If not specified, both land price public
-          notices and prefectural land price surveys.
+          the real estate price endpoints take. If not specified, both the publication and
+          the prefectural research.
         :param use_category_code: One use division code, or a sequence of them.
           See https://www.reinfolib.mlit.go.jp/help/apiManual/#titleApi8
-        :return: land price public notices (standard land prices) and
-        prefectural land price surveys (benchmark land prices) point. (Response format: GeoJson)
+        :return: Land market value publication and land market value research point.
+          (Response format: GeoJson)
         :raises ValueError: If `z` is not between 13 and 15, or `use_category_code` is empty.
         """
         return self._get_tile(

--- a/pyreinfolib/enums.py
+++ b/pyreinfolib/enums.py
@@ -22,13 +22,16 @@ class LandPriceClassification(StrEnum):
     A separate code table from `PriceClassification`, numbered from `0` rather than `01`, so
     the two are not interchangeable even though the API spells both `priceClassification`.
     Leaving the argument unset asks for both.
+
+    MLIT distinguishes the two by 公示 and 調査: the first is a publication, the second is
+    research. Rendering both as "publication" would leave the members nearly identical.
     """
 
     # 地価公示
-    LAND_PRICE_PUBLIC_NOTICE = "0"
+    LAND_MARKET_VALUE_PUBLICATION = "0"
 
     # 都道府県地価調査
-    PREFECTURAL_LAND_PRICE_SURVEY = "1"
+    PREFECTURAL_LAND_MARKET_VALUE_RESEARCH = "1"
 
 
 @unique

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -33,7 +33,7 @@ THROTTLED = {"json": {"message": "slow down"}, "status": 429}
 # to be per endpoint rather than one shared range.
 TILE_ENDPOINTS = [
     ("get_real_estate_prices_point", "XPT001", {"period_from": 20241, "period_to": 20241}, range(11, 16)),
-    ("get_land_price_public_notices_and_surveys_point", "XPT002", {"year": 2020}, range(13, 16)),
+    ("get_land_market_value_publication_and_research_point", "XPT002", {"year": 2020}, range(13, 16)),
     ("get_number_of_passengers_per_station", "XKT015", {}, range(11, 16)),
 ]
 TILE_ENDPOINT_IDS = ["XPT001", "XPT002", "XKT015"]
@@ -547,7 +547,7 @@ class TestClient:
                     "x": 7312,
                     "y": 3008,
                     "year": 2020,
-                    "price_classification": LandPriceClassification.LAND_PRICE_PUBLIC_NOTICE,
+                    "price_classification": LandPriceClassification.LAND_MARKET_VALUE_PUBLICATION,
                     "use_category_code": [UseDivision.RESIDENTIAL_LAND, UseDivision.COMMERCIAL_LAND],
                 },
                 expected_params={
@@ -592,8 +592,8 @@ class TestClient:
         ],
         ids=lambda case: case.id,
     )
-    def test_get_land_price_public_notices_and_surveys_point(self, mock_api, client, case):
-        assert_request(mock_api, client.get_land_price_public_notices_and_surveys_point, "XPT002", case)
+    def test_get_land_market_value_publication_and_research_point(self, mock_api, client, case):
+        assert_request(mock_api, client.get_land_market_value_publication_and_research_point, "XPT002", case)
 
     @pytest.mark.parametrize(
         "case",
@@ -618,7 +618,7 @@ class TestClient:
                 {"z": 11, "x": 1819, "y": 806, "period_from": 20241, "period_to": 20241},
             ),
             (
-                "get_land_price_public_notices_and_surveys_point",
+                "get_land_market_value_publication_and_research_point",
                 "XPT002",
                 {"z": 13, "x": 7312, "y": 3008, "year": 2020},
             ),
@@ -683,14 +683,14 @@ class TestClient:
         API answers a tile it has no data for with an empty feature list rather than an error.
         """
         with pytest.raises(ValueError, match="XPT002"):
-            client.get_land_price_public_notices_and_surveys_point(z=z, x=7312, y=3008, year=2020)
+            client.get_land_market_value_publication_and_research_point(z=z, x=7312, y=3008, year=2020)
 
     def test_the_rejection_names_the_endpoint_and_the_range(self, mock_api, client):
         """With 33 tile endpoints and more than one range among them, "z must be 11 to 15" on
         its own does not tell the caller which endpoint disagreed.
         """
         with pytest.raises(ValueError) as exc_info:
-            client.get_land_price_public_notices_and_surveys_point(z=11, x=7312, y=3008, year=2020)
+            client.get_land_market_value_publication_and_research_point(z=11, x=7312, y=3008, year=2020)
 
         message = str(exc_info.value)
         assert "XPT002" in message
@@ -788,7 +788,7 @@ class TestBlankArguments:
                 "landTypeCode",
             ),
             (
-                "get_land_price_public_notices_and_surveys_point",
+                "get_land_market_value_publication_and_research_point",
                 {"z": 13, "x": 7312, "y": 3008, "year": 2020, "use_category_code": []},
                 "useCategoryCode",
             ),

--- a/tests/typing_usage.py
+++ b/tests/typing_usage.py
@@ -52,7 +52,7 @@ def tile_endpoints_from_a_point(client: Client) -> None:
     client.get_number_of_passengers_per_station(*tile)
     client.get_number_of_passengers_per_station(z=tile.z, x=tile.x, y=tile.y)
     client.get_real_estate_prices_point(*tile, period_from=20241, period_to=20242)
-    client.get_land_price_public_notices_and_surveys_point(*tile, year=2020)
+    client.get_land_market_value_publication_and_research_point(*tile, year=2020)
 
 
 def tile_endpoints_over_an_extent(client: Client) -> None:
@@ -100,12 +100,12 @@ def code_sequences(client: Client) -> None:
         period_to=20242,
         land_type_code=[LandTypeCode.LAND, LandTypeCode.FOREST_LAND],
     )
-    client.get_land_price_public_notices_and_surveys_point(
+    client.get_land_market_value_publication_and_research_point(
         z=13,
         x=7312,
         y=3008,
         year=2020,
-        price_classification=LandPriceClassification.LAND_PRICE_PUBLIC_NOTICE,
+        price_classification=LandPriceClassification.LAND_MARKET_VALUE_PUBLICATION,
         use_category_code=[UseDivision.RESIDENTIAL_LAND, UseDivision.COMMERCIAL_LAND],
     )
 
@@ -147,7 +147,7 @@ def rejected_by_the_checker(client: Client) -> None:
     fail the run, so each of these fails the build if the rejection ever stops happening.
     """
     # The two price classification tables are not interchangeable.
-    client.get_land_price_public_notices_and_surveys_point(
+    client.get_land_market_value_publication_and_research_point(
         z=13,
         x=7312,
         y=3008,
@@ -156,7 +156,7 @@ def rejected_by_the_checker(client: Client) -> None:
     )
     client.get_real_estate_prices(
         year=2024,
-        price_classification=LandPriceClassification.LAND_PRICE_PUBLIC_NOTICE,  # ty: ignore[invalid-argument-type]
+        price_classification=LandPriceClassification.LAND_MARKET_VALUE_PUBLICATION,  # ty: ignore[invalid-argument-type]
     )
 
     # A bare code string is no longer accepted for a parameter that has an enum.


### PR DESCRIPTION
The names for 地価公示 and 都道府県地価調査 used terminology MLIT has moved away from. Its English page for the programme is titled [Land Market Value Publication (Previously called the "Land price public notice system")](https://www.mlit.go.jp/en/totikensangyo/totikensangyo_fr4_000001.html), and its glossary records why: `Public notice という訳もあるようだが、通達と紛らわしい`.

## Changes

- `LandPriceClassification.LAND_PRICE_PUBLIC_NOTICE` becomes `LAND_MARKET_VALUE_PUBLICATION`
- `LandPriceClassification.PREFECTURAL_LAND_PRICE_SURVEY` becomes `PREFECTURAL_LAND_MARKET_VALUE_RESEARCH`
- `get_land_price_public_notices_and_surveys_point` becomes `get_land_market_value_publication_and_research_point`
- Docstrings drop "standard land prices" and "benchmark land prices" for the sourced wording
- CONTRIBUTING.md: [the MLIT glossary](https://www.mlit.go.jp/common/000214955.pdf) added as a source, seven terms moved to 確定, and the two decisions below recorded

## Notes

- The glossary is MLIT's own, produced to settle this vocabulary（統一的な英語訳を提示することを目的として）. It is more specific on land price terms than the Japanese Law Translation Database and annotates the database's renderings, so it sits above the ministry's general English pages in the source order.
- 公示 and 調査 are separated as Publication and Research. Entry 259 renders 都道府県地価調査 descriptively and reuses "publication", which would have left the two members nearly identical; the proper-noun forms of the two MLIT offices, 地価公示室 and 地価調査課, are what distinguish them.
- The glossary writes `Land （Market） Value` with the parenthetical. Identifiers cannot carry it, and the English page runs the name without, so it is dropped.
- The method name grows from 46 to 52 characters. The rule in CONTRIBUTING.md does not treat length as a criterion, and whether that rule should change is a separate question.

BREAKING CHANGE: `get_land_price_public_notices_and_surveys_point` is now `get_land_market_value_publication_and_research_point`, and `LandPriceClassification.LAND_PRICE_PUBLIC_NOTICE` and `PREFECTURAL_LAND_PRICE_SURVEY` are now `LAND_MARKET_VALUE_PUBLICATION` and `PREFECTURAL_LAND_MARKET_VALUE_RESEARCH`. The codes and the behaviour are unchanged; only the names move.
