### PR TITLE
feat: add the tile endpoints that filter by municipality code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,14 @@ API 側が改称したとき、追随すべきかの判断がつきます。
 - **メソッド名**は返り値に合わせます。一覧が返るなら複数（`get_municipalities`）
 - **enum メンバー**は単数です（`RESIDENTIAL_LAND`、`LAND_AND_BUILDING`）
 
+### 引数名は API のパラメータ名を snake_case にしただけにします
+
+`administrativeAreaCode` → `administrative_area_code`、`welfareFacilityMiddleClassCode` → `welfare_facility_middle_class_code` です。メソッド名と違って導出手順はありません。
+
+**同じコード表でも API の綴りが違えば引数名も分けます。** 市区町村コードは XIT001 では `city`、XKT004 などでは `administrativeAreaCode` です。同じ5桁のコード表ですが、片方に寄せると寄せなかった側の引数名が、利用者がマニュアルで読むパラメータ名と一致しなくなります。docstring で同じコード表だと伝えます。
+
+例外は Python の予約語と衝突する場合です。XPT001 の `from` / `to` は `period_from` / `period_to` にしています。
+
 ### 導出例
 
 規則が既存の6メソッドを再現することを確認済みです。
@@ -114,6 +122,29 @@ API 側が改称したとき、追随すべきかの判断がつきます。
 **値に意味が読み取れるものは `Literal` のままにします。** `quarter: Literal[1, 2, 3, 4]`、`language: Literal["ja", "en"]`、`z: Literal[11, 12, 13, 14, 15]` はそのままで十分です。
 
 `StrEnum` を使います。実行時は文字列としても動くので、型チェックだけが新しい制約になります。
+
+### enum にするか `str` にするか
+
+コード表が enum になる条件は2つあり、両方必要です。
+
+- **数えられる規模である。** `UseDivision` は8件、`LandTypeCode` は5件です。都道府県コード（47件）と市区町村コード（約1900件）は `area`、`city`、`administrative_area_code` として `str` のままにし、docstring にコード表の URL を置いています
+- **全メンバーに典拠のある訳語がある。** 一部しか訳せないコード表は enum にしません。呼び出し側が同じ引数に enum メンバーと生の文字列を混ぜることになり、enum を作った意味がなくなります
+
+福祉施設大分類コード（XKT011）が2つ目に当たる例です。7件で規模は足りていますが、うち2件に公表された英訳がありません。
+
+| コード | 用語 | 英訳 | 典拠 |
+|---|---|---|---|
+| 01 | 保護施設 | public assistance facility | 生活保護法 第六章、38条（[laws/view/24](https://www.japaneselawtranslation.go.jp/ja/laws/view/24/je)） |
+| 02 | 老人福祉施設 | welfare facility for the elderly | 老人福祉法5条の3（[laws/view/3930](https://www.japaneselawtranslation.go.jp/ja/laws/view/3930/je)） |
+| 03 | 障害者支援施設等 | support facility for persons with disabilities | 障害者総合支援法5条11項（[laws/view/4093](https://www.japaneselawtranslation.go.jp/ja/laws/view/4093/je)） |
+| 04 | 身体障害者社会参加支援施設 | **なし** | 身体障害者福祉法5条。法令訳DBに収録なし |
+| 05 | 児童福祉施設等 | child welfare institution | 児童福祉法7条1項（[laws/view/4035](https://www.japaneselawtranslation.go.jp/ja/laws/view/4035/je)） |
+| 06 | 母子・父子福祉施設 | **なし** | 母子及び父子並びに寡婦福祉法38条。法令訳DBに収録なし |
+| 99 | その他の社会福祉施設等 | social welfare facility | 社会福祉法62条（[laws/view/3813](https://www.japaneselawtranslation.go.jp/ja/laws/view/3813/je)） |
+
+上の5件は[厚生労働白書の英語版](https://www.mhlw.go.jp/wp/hakusyo/kousei/11-2/kousei-data/PDF/23010804_en.pdf)でも同じ組み合わせで使われています。04 と 06 は厚生労働省の英語資料でも旧称で揺れていて（`rehabilitation facilities for people with physical disabilities` など）、現行名の定訳がありません。
+
+**後から enum を足すのは非破壊的です。** `Sequence[str] | str | None` は `Sequence[WelfareFacilityClassCode | str] | WelfareFacilityClassCode | str | None` に広げられ、`str` を受け続けるので既存の呼び出しは壊れません。逆に `str` を enum だけに絞るのは壊れます。迷ったら `str` から始めてください。
 
 ### コード体系が別なら enum も分けます
 
@@ -141,6 +172,8 @@ class PriceClassification(StrEnum):
 2. **[地価に関する国際的な情報発信の強化に向けた検討業務 調査報告書](https://www.mlit.go.jp/common/000214955.pdf)**（国土交通省 土地・建設産業局、平成24年3月）。地価公示・鑑定評価の語彙について、MLIT が統一的な英訳を提示する目的で作成した用語集です。地価関連語は法令訳DBより詳しく、DBの訳に対する明示的な注記もあります
 3. **所管省庁の英語版資料**。法令用語でないもの（統計用語、データセット名）
 4. **既にこのライブラリで使っている訳語**。1〜3で確認できないもの
+
+1〜4のどこにも訳語がない語があります。根拠法が法令訳DBに未収録で、所管省庁の英語資料も旧称のまま揺れている場合です。訳語を発明せず、その語を名前にしない設計を選んでください。コード表なら「[enum にするか `str` にするか](#enum-にするか-str-にするか)」の通り `str` のままにします。
 
 ### 確定
 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,40 @@ from pyreinfolib import tiles
 client.get_use_districts(*tiles.containing(lon=139.7016, lat=35.6580, z=15))
 ```
 
+### 行政区域コードで絞り込めるAPI
+
+次の4本はタイル座標に加えて `administrative_area_code`（行政区域コード、5桁）を取ります。**任意**なので、省略すればタイル全体が返ります。
+
+| メソッド | ID | データ | ズーム |
+|---|---|---|---|
+| `get_elementary_school_districts` | XKT004 | 小学校区 | 11〜15 |
+| `get_junior_high_school_districts` | XKT005 | 中学校区 | 11〜15 |
+| `get_welfare_facilities` | XKT011 | 福祉施設 | 13〜15 |
+| `get_libraries` | XKT017 | 図書館 | 13〜15 |
+
+```python
+client.get_libraries(*tiles.containing(lon=139.7016, lat=35.6580, z=15))
+
+# 1つでも、複数でも渡せます
+client.get_elementary_school_districts(z=11, x=1819, y=806, administrative_area_code="13102")
+client.get_elementary_school_districts(z=11, x=1819, y=806, administrative_area_code=["01101", "13102"])
+```
+
+不動産取引価格情報の `city` と同じ市区町村コードですが、APIが `administrativeAreaCode` と綴っているため引数名も分けています。
+
+`get_welfare_facilities` は施設種別でも絞り込めます。大分類・中分類・小分類の3階層で、いずれも任意です。
+
+```python
+client.get_welfare_facilities(
+    z=13,
+    x=7312,
+    y=3008,
+    welfare_facility_class_code=["02", "05"],  # 老人福祉施設、児童福祉施設等
+)
+```
+
+コード表は[大分類](https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMajorClassificationCode.html)、[中分類](https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMiddleClassificationCode.html)、[小分類](https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMinorClassificationCode.html)にあります。enum ではなく `str` です。中分類62件・小分類122件という規模に加えて、大分類7件のうち2件に公表された英訳がないためです（[CONTRIBUTING.md](CONTRIBUTING.md#enum-にするか-str-にするか)）。
+
 ## タイル座標
 
 公開APIの多くは場所ではなく XYZ タイル座標で引きます。緯度経度から変換するために `pyreinfolib.tiles` を用意しています。ネットワークもAPIキーも不要な純粋関数です。

--- a/pyreinfolib/client.py
+++ b/pyreinfolib/client.py
@@ -412,6 +412,62 @@ class Client:
         """
         return self._get_tile("XKT002", z, x, y)
 
+    def get_elementary_school_districts(
+        self,
+        z: int,
+        x: int,
+        y: int,
+        administrative_area_code: Sequence[str] | str | None = None,
+    ) -> dict[str, Any]:
+        """Get elementary school districts (小学校区).
+        See https://www.reinfolib.mlit.go.jp/help/apiManual/xkt004/ for details.
+        :param z: Zoom level (scale). 11 (city) ~ 15 (detail)
+        :param x: x value of tile coordinates.
+        :param y: y value of tile coordinates.
+        :param administrative_area_code: One municipality code, or a sequence of them.
+          Format: NNNNN. The same code table the price endpoints spell `city`.
+          See https://nlftp.mlit.go.jp/ksj/gml/codelist/AdminiBoundary_CD.xlsx
+          If not specified, the whole tile.
+        :return: Elementary school districts. (Response format: GeoJson)
+        :raises ValueError: If `z` is not between 11 and 15, or `administrative_area_code`
+          is empty.
+        """
+        return self._get_tile(
+            "XKT004",
+            z,
+            x,
+            y,
+            {"administrativeAreaCode": _join_codes(administrative_area_code)},
+        )
+
+    def get_junior_high_school_districts(
+        self,
+        z: int,
+        x: int,
+        y: int,
+        administrative_area_code: Sequence[str] | str | None = None,
+    ) -> dict[str, Any]:
+        """Get junior high school districts (中学校区).
+        See https://www.reinfolib.mlit.go.jp/help/apiManual/xkt005/ for details.
+        :param z: Zoom level (scale). 11 (city) ~ 15 (detail)
+        :param x: x value of tile coordinates.
+        :param y: y value of tile coordinates.
+        :param administrative_area_code: One municipality code, or a sequence of them.
+          Format: NNNNN. The same code table the price endpoints spell `city`.
+          See https://nlftp.mlit.go.jp/ksj/gml/codelist/AdminiBoundary_CD.xlsx
+          If not specified, the whole tile.
+        :return: Junior high school districts. (Response format: GeoJson)
+        :raises ValueError: If `z` is not between 11 and 15, or `administrative_area_code`
+          is empty.
+        """
+        return self._get_tile(
+            "XKT005",
+            z,
+            x,
+            y,
+            {"administrativeAreaCode": _join_codes(administrative_area_code)},
+        )
+
     def get_schools(self, z: int, x: int, y: int) -> dict[str, Any]:
         """Get schools (学校).
         See https://www.reinfolib.mlit.go.jp/help/apiManual/xkt006/ for details.
@@ -444,6 +500,61 @@ class Client:
         :raises ValueError: If `z` is not between 13 and 15.
         """
         return self._get_tile("XKT010", z, x, y, zoom_levels=range(13, 16))
+
+    def get_welfare_facilities(
+        self,
+        z: int,
+        x: int,
+        y: int,
+        administrative_area_code: Sequence[str] | str | None = None,
+        welfare_facility_class_code: Sequence[str] | str | None = None,
+        welfare_facility_middle_class_code: Sequence[str] | str | None = None,
+        welfare_facility_minor_class_code: Sequence[str] | str | None = None,
+    ) -> dict[str, Any]:
+        """Get welfare facilities (福祉施設).
+
+        The three class codes are one nested classification at three levels of detail, and
+        they are `str` rather than enums. Two of the seven major classes have no published
+        English name -- 身体障害者社会参加支援施設 and 母子・父子福祉施設 rest on the two
+        welfare acts that the Japanese Law Translation database does not carry -- and an enum
+        naming five of seven would leave the caller mixing members with bare strings for the
+        same argument. `area` and `city` are `str` for the same reason.
+        See https://www.reinfolib.mlit.go.jp/help/apiManual/xkt011/ for details.
+        :param z: Zoom level (scale). 13 ~ 15 (detail)
+        :param x: x value of tile coordinates.
+        :param y: y value of tile coordinates.
+        :param administrative_area_code: One municipality code, or a sequence of them.
+          Format: NNNNN. The same code table the price endpoints spell `city`.
+          See https://nlftp.mlit.go.jp/ksj/gml/codelist/AdminiBoundary_CD.xlsx
+          If not specified, the whole tile.
+        :param welfare_facility_class_code: One major class code, or a sequence of them.
+          Format: NN. See
+          https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMajorClassificationCode.html
+          If not specified, every class.
+        :param welfare_facility_middle_class_code: One middle class code, or a sequence of
+          them. Format: NNNN. See
+          https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMiddleClassificationCode.html
+          If not specified, every class.
+        :param welfare_facility_minor_class_code: One minor class code, or a sequence of
+          them. Format: NNNNNN. See
+          https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMinorClassificationCode.html
+          If not specified, every class.
+        :return: Welfare facilities. (Response format: GeoJson)
+        :raises ValueError: If `z` is not between 13 and 15, or a code argument is empty.
+        """
+        return self._get_tile(
+            "XKT011",
+            z,
+            x,
+            y,
+            {
+                "administrativeAreaCode": _join_codes(administrative_area_code),
+                "welfareFacilityClassCode": _join_codes(welfare_facility_class_code),
+                "welfareFacilityMiddleClassCode": _join_codes(welfare_facility_middle_class_code),
+                "welfareFacilityMinorClassCode": _join_codes(welfare_facility_minor_class_code),
+            },
+            zoom_levels=range(13, 16),
+        )
 
     def get_future_population_estimates_by_250m_mesh(self, z: int, x: int, y: int) -> dict[str, Any]:
         """Get future population estimates by 250m mesh (将来推計人口250mメッシュ).
@@ -489,6 +600,35 @@ class Client:
         :raises ValueError: If `z` is not between 11 and 15.
         """
         return self._get_tile("XKT015", z, x, y)
+
+    def get_libraries(
+        self,
+        z: int,
+        x: int,
+        y: int,
+        administrative_area_code: Sequence[str] | str | None = None,
+    ) -> dict[str, Any]:
+        """Get libraries (図書館).
+        See https://www.reinfolib.mlit.go.jp/help/apiManual/xkt017/ for details.
+        :param z: Zoom level (scale). 13 ~ 15 (detail)
+        :param x: x value of tile coordinates.
+        :param y: y value of tile coordinates.
+        :param administrative_area_code: One municipality code, or a sequence of them.
+          Format: NNNNN. The same code table the price endpoints spell `city`.
+          See https://nlftp.mlit.go.jp/ksj/gml/codelist/AdminiBoundary_CD.xlsx
+          If not specified, the whole tile.
+        :return: Libraries. (Response format: GeoJson)
+        :raises ValueError: If `z` is not between 13 and 15, or `administrative_area_code`
+          is empty.
+        """
+        return self._get_tile(
+            "XKT017",
+            z,
+            x,
+            y,
+            {"administrativeAreaCode": _join_codes(administrative_area_code)},
+            zoom_levels=range(13, 16),
+        )
 
     def get_municipal_offices_and_public_meeting_facilities_etc(self, z: int, x: int, y: int) -> dict[str, Any]:
         """Get municipal offices and public meeting facilities etc. (市区町村役場及び集会施設等).

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -35,8 +35,23 @@ TILE_ENDPOINTS = [
     ("get_real_estate_prices_point", "XPT001", {"period_from": 20241, "period_to": 20241}, range(11, 16)),
     ("get_land_market_value_publication_and_research_point", "XPT002", {"year": 2020}, range(13, 16)),
     ("get_number_of_passengers_per_station", "XKT015", {}, range(11, 16)),
+    ("get_elementary_school_districts", "XKT004", {}, range(11, 16)),
+    ("get_junior_high_school_districts", "XKT005", {}, range(11, 16)),
+    ("get_welfare_facilities", "XKT011", {}, range(13, 16)),
+    ("get_libraries", "XKT017", {}, range(13, 16)),
 ]
-TILE_ENDPOINT_IDS = ["XPT001", "XPT002", "XKT015"]
+TILE_ENDPOINT_IDS = ["XPT001", "XPT002", "XKT015", "XKT004", "XKT005", "XKT011", "XKT017"]
+
+# Tile endpoints whose only further parameters are optional filters, with the API's spelling
+# of the municipality code filter every one of them takes. Listed together because the filter
+# behaves the same across them: omitted means the whole tile, and a sequence is comma joined.
+FILTERED_TILE_ENDPOINTS = [
+    ("get_elementary_school_districts", "XKT004", 11),
+    ("get_junior_high_school_districts", "XKT005", 11),
+    ("get_welfare_facilities", "XKT011", 13),
+    ("get_libraries", "XKT017", 13),
+]
+FILTERED_TILE_ENDPOINT_IDS = [endpoint for _, endpoint, _ in FILTERED_TILE_ENDPOINTS]
 
 
 @dataclass
@@ -792,8 +807,35 @@ class TestBlankArguments:
                 {"z": 13, "x": 7312, "y": 3008, "year": 2020, "use_category_code": []},
                 "useCategoryCode",
             ),
+            (
+                "get_elementary_school_districts",
+                {"z": 11, "x": 1819, "y": 806, "administrative_area_code": []},
+                "administrativeAreaCode",
+            ),
+            (
+                "get_welfare_facilities",
+                {"z": 13, "x": 7312, "y": 3008, "welfare_facility_class_code": []},
+                "welfareFacilityClassCode",
+            ),
+            (
+                "get_welfare_facilities",
+                {"z": 13, "x": 7312, "y": 3008, "welfare_facility_middle_class_code": []},
+                "welfareFacilityMiddleClassCode",
+            ),
+            (
+                "get_welfare_facilities",
+                {"z": 13, "x": 7312, "y": 3008, "welfare_facility_minor_class_code": []},
+                "welfareFacilityMinorClassCode",
+            ),
         ],
-        ids=["land_type_code", "use_category_code"],
+        ids=[
+            "land_type_code",
+            "use_category_code",
+            "administrative_area_code",
+            "welfare_facility_class_code",
+            "welfare_facility_middle_class_code",
+            "welfare_facility_minor_class_code",
+        ],
     )
     def test_an_empty_sequence_of_codes_is_refused(self, mock_api, client, method_name, args, expected):
         """A list that filtered down to nothing is not a request for every code."""
@@ -912,3 +954,128 @@ class TestTileOnlyEndpoints:
             getattr(client, method_name)(*tile)
 
         assert len(mock_api.calls) == len(TILE_ONLY_ENDPOINTS)
+
+
+class TestTileEndpointsWithOptionalFilters:
+    """XKT004, XKT005, XKT011 and XKT017 take filters on top of the coordinates.
+
+    Every filter is optional: the manual marks only `response_format`, `z`, `x` and `y` as
+    required. So each of these is also callable with the coordinates alone, and that has to
+    stay true -- a filter that acquired a default would narrow every caller's results.
+    """
+
+    @pytest.mark.parametrize(
+        ("method_name", "endpoint", "zoom"), FILTERED_TILE_ENDPOINTS, ids=FILTERED_TILE_ENDPOINT_IDS
+    )
+    def test_it_requests_its_own_endpoint_with_the_coordinates_alone(
+        self, mock_api, client, method_name, endpoint, zoom
+    ):
+        """The endpoint id is the one thing a copied method body gets wrong silently.
+
+        `expected_params` is compared whole, so a filter that leaked a default value into the
+        query string would fail here rather than quietly narrowing the response.
+        """
+        assert_request(
+            mock_api,
+            getattr(client, method_name),
+            endpoint,
+            RequestCase(
+                id="tile coordinates only",
+                args={"z": zoom, "x": 1819, "y": 806},
+                expected_params={"response_format": "geojson", "z": str(zoom), "x": "1819", "y": "806"},
+            ),
+        )
+
+    @pytest.mark.parametrize(
+        ("method_name", "endpoint", "zoom"), FILTERED_TILE_ENDPOINTS, ids=FILTERED_TILE_ENDPOINT_IDS
+    )
+    def test_a_single_municipality_code_is_sent_unchanged(self, mock_api, client, method_name, endpoint, zoom):
+        """A bare string has to survive whole.
+
+        `",".join()` treats a string as a sequence of characters, so without the check in
+        `_join_codes` this would send `1,3,1,0,2` instead of `13102`.
+        """
+        assert_request(
+            mock_api,
+            getattr(client, method_name),
+            endpoint,
+            RequestCase(
+                id="one code",
+                args={"z": zoom, "x": 1819, "y": 806, "administrative_area_code": "13102"},
+                expected_params={
+                    "response_format": "geojson",
+                    "z": str(zoom),
+                    "x": "1819",
+                    "y": "806",
+                    "administrativeAreaCode": "13102",
+                },
+            ),
+        )
+
+    @pytest.mark.parametrize(
+        ("method_name", "endpoint", "zoom"), FILTERED_TILE_ENDPOINTS, ids=FILTERED_TILE_ENDPOINT_IDS
+    )
+    def test_several_municipality_codes_are_comma_joined(self, mock_api, client, method_name, endpoint, zoom):
+        assert_request(
+            mock_api,
+            getattr(client, method_name),
+            endpoint,
+            RequestCase(
+                id="several codes",
+                args={"z": zoom, "x": 1819, "y": 806, "administrative_area_code": ["01101", "13102"]},
+                expected_params={
+                    "response_format": "geojson",
+                    "z": str(zoom),
+                    "x": "1819",
+                    "y": "806",
+                    "administrativeAreaCode": "01101,13102",
+                },
+            ),
+        )
+
+    def test_the_welfare_facility_classes_are_three_separate_filters(self, mock_api, client):
+        """Major, middle and minor are one nested classification, but three parameters.
+
+        The names differ by a single word and the digit counts differ by two, so a pair
+        swapped at the call site would reach the API as a code of the wrong width. Pinned
+        together to keep each argument mapped to the parameter that carries its width.
+        """
+        assert_request(
+            mock_api,
+            client.get_welfare_facilities,
+            "XKT011",
+            RequestCase(
+                id="all three levels",
+                args={
+                    "z": 13,
+                    "x": 7312,
+                    "y": 3008,
+                    "administrative_area_code": "13102",
+                    "welfare_facility_class_code": ["01", "02"],
+                    "welfare_facility_middle_class_code": "0101",
+                    "welfare_facility_minor_class_code": ["020101", "020102"],
+                },
+                expected_params={
+                    "response_format": "geojson",
+                    "z": "13",
+                    "x": "7312",
+                    "y": "3008",
+                    "administrativeAreaCode": "13102",
+                    "welfareFacilityClassCode": "01,02",
+                    "welfareFacilityMiddleClassCode": "0101",
+                    "welfareFacilityMinorClassCode": "020101,020102",
+                },
+            ),
+        )
+
+    @pytest.mark.parametrize(
+        ("method_name", "endpoint", "zoom"), FILTERED_TILE_ENDPOINTS, ids=FILTERED_TILE_ENDPOINT_IDS
+    )
+    def test_a_tile_from_the_helpers_reaches_it(self, mock_api, client, method_name, endpoint, zoom):
+        """`*tile` unpacks into `z`, `x`, `y`, which the filters must not displace."""
+        mock_api.get(f"{BASE_URL}{endpoint}", json=DUMMY_RESPONSE)
+        tile = tiles.containing(lon=139.7016, lat=35.6580, z=zoom)
+
+        assert getattr(client, method_name)(*tile) == DUMMY_RESPONSE
+
+        assert params_of(mock_api.calls[0].request)["z"] == str(zoom)

--- a/tests/typing_usage.py
+++ b/tests/typing_usage.py
@@ -54,6 +54,13 @@ def tile_endpoints_from_a_point(client: Client) -> None:
     client.get_real_estate_prices_point(*tile, period_from=20241, period_to=20242)
     client.get_land_market_value_publication_and_research_point(*tile, year=2020)
 
+    # The endpoints whose further parameters are all optional. `*tile` has to fill `z`, `x`
+    # and `y` without a filter being passed positionally into one of them.
+    client.get_elementary_school_districts(*tile)
+    client.get_junior_high_school_districts(*tile)
+    client.get_libraries(*tile)
+    client.get_welfare_facilities(*tile)
+
 
 def tile_endpoints_over_an_extent(client: Client) -> None:
     """The other idiom #45 fixed, and the one that matters for anything larger than a point."""
@@ -107,6 +114,27 @@ def code_sequences(client: Client) -> None:
         year=2020,
         price_classification=LandPriceClassification.LAND_MARKET_VALUE_PUBLICATION,
         use_category_code=[UseDivision.RESIDENTIAL_LAND, UseDivision.COMMERCIAL_LAND],
+    )
+
+
+def municipality_code_filters(client: Client) -> None:
+    """The tile filters are `str`, so a bare code and a sequence of them both type check.
+
+    Unlike `land_type_code`, these have no enum: the municipality table runs to thousands of
+    entries, and two of the seven welfare facility major classes have no published English
+    name to take a member name from.
+    """
+    client.get_elementary_school_districts(z=11, x=1819, y=806, administrative_area_code="13102")
+    client.get_junior_high_school_districts(z=11, x=1819, y=806, administrative_area_code=["01101", "13102"])
+    client.get_libraries(z=13, x=7312, y=3008, administrative_area_code="13102")
+    client.get_welfare_facilities(
+        z=13,
+        x=7312,
+        y=3008,
+        administrative_area_code="13102",
+        welfare_facility_class_code=["01", "02"],
+        welfare_facility_middle_class_code="0101",
+        welfare_facility_minor_class_code=["020101", "020102"],
     )
 
 


### PR DESCRIPTION
Four endpoints that take filters on top of the tile coordinates. Every filter is optional, so each is also callable with the coordinates alone.

Argument naming and the choice between an enum and `str` for a code table were not written down, so the rules these four needed are now in CONTRIBUTING.md.

## Changes

- `get_elementary_school_districts` (XKT004, zoom 11-15)
- `get_junior_high_school_districts` (XKT005, zoom 11-15)
- `get_welfare_facilities` (XKT011, zoom 13-15)
- `get_libraries` (XKT017, zoom 13-15)
- Rule: an argument name is the API parameter name in snake_case, nothing more
- Rule: when a code table becomes an enum and when it stays `str`
- The translation sources found for the seven welfare facility major classes

## Notes

The welfare facility code table has 7 major, 62 middle and 122 minor classes. The middle and minor levels only turned up after re-extracting the manual pages with a pattern that allows parameter names of 30 characters and over.
