### PR TITLE
feat: add the natural park and emergency evacuation site endpoints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,14 @@ class PriceClassification(StrEnum):
 | 標準地 | standard site | MLIT 用語集 275 |
 | 基準地 | standard site published by the prefectural government | MLIT 用語集 48 |
 | 土地鑑定委員会 | Land Appraisal Committee | [MLIT 英語ページ](https://www.mlit.go.jp/en/totikensangyo/totikensangyo_fr4_000001.html) |
+| 自然公園 | natural park | 自然公園法2条1号（[laws/view/3060](https://www.japaneselawtranslation.go.jp/ja/laws/view/3060/je)） |
+| 国立公園 | national park | 自然公園法2条2号 |
+| 国定公園 | quasi-national park | 自然公園法2条3号 |
+| 都道府県立自然公園 | prefectural natural park | 自然公園法2条4号 |
+| 特別地域 | special area | 自然公園法20条 |
+| 普通地域 | ordinary area | 自然公園法33条 |
+| 指定緊急避難場所 | designated emergency evacuation site | 災害対策基本法第7章2節、49条の4（[laws/view/4171](https://www.japaneselawtranslation.go.jp/ja/laws/view/4171/je)） |
+| 指定避難所 | designated shelter | 災害対策基本法49条の7 |
 
 MLIT 用語集は `Land （Market） Value` と括弧付きで記載していますが、識別子に括弧は使えず、[MLIT の英語ページ](https://www.mlit.go.jp/en/totikensangyo/totikensangyo_fr4_000001.html)が括弧なしで運用しているため、括弧を外した形を採用します。
 
@@ -219,21 +227,23 @@ MLIT 用語集は `Land （Market） Value` と括弧付きで記載していま
 
 | 用語 | 典拠を探す先 | 用途 |
 |---|---|---|
-| 立地適正化計画 | 都市再生特別措置法 | XKT003 |
+| 立地適正化計画 | 都市再生特別措置法（法令訳DBに収録なし） | XKT003 |
 | 災害危険区域 | 建築基準法39条 | XKT016 |
-| 自然公園地域 | 自然公園法 | XKT019 |
 | 大規模盛土造成地 | 国土交通省 | XKT020 |
-| 地すべり防止区域 | 地すべり等防止法 | XKT021 |
-| 急傾斜地崩壊危険区域 | 急傾斜地法 | XKT022 |
+| 地すべり防止区域 | 地すべり等防止法（法令訳DBに収録なし） | XKT021 |
+| 急傾斜地崩壊危険区域 | 急傾斜地法（法令訳DBに収録なし） | XKT022 |
 | 地形区分に基づく液状化の発生傾向図 | 国土交通省都市局 | XKT025 |
-| 洪水浸水想定区域 | 水防法 | XKT026 |
-| 高潮浸水想定区域 | 水防法 | XKT027 |
-| 津波浸水想定 | 津波防災地域づくり法 | XKT028 |
-| 土砂災害警戒区域 | 土砂災害防止法 | XKT029 |
+| 洪水浸水想定区域 | 水防法（法令訳DBに収録なし） | XKT026 |
+| 高潮浸水想定区域 | 水防法（法令訳DBに収録なし） | XKT027 |
+| 津波浸水想定 | 津波防災地域づくり法（法令訳DBに収録なし） | XKT028 |
+| 土砂災害警戒区域 | 土砂災害防止法（法令訳DBに収録なし） | XKT029 |
 | 都市計画道路 | 都市計画法（簡潔な定訳がなく判断が必要） | XKT030 |
 | 人口集中地区 | 総務省統計局（国勢調査英語版で Densely Inhabited District / DID が定着） | XKT031 |
-| 指定緊急避難場所 | 災害対策基本法 | XGT001 |
 | 災害履歴 | 国土調査（土地履歴調査） | XST001 |
+
+**「法令訳DBに収録なし」は確認済みです。** 法令検索で法令名を引いて0件でした。優先順位1が使えないので、これらは3（所管省庁の英語版資料）に降りることになります。同じ確認を繰り返さないよう結果を残しています。
+
+法令訳DBの引き方は、法令名から翻訳IDを引いて `https://www.japaneselawtranslation.go.jp/ja/laws/view/{id}/je` を開きます。対訳ページは日本語と英語の div が交互に並ぶので、定義条（「この法律において『○○』とは」）を見ると定義語の訳が取れます。辞書検索（標準対訳辞書）は一般的な法令用語しか収録しておらず、施設名や区域名は引けません。
 
 XKT004〜018 の施設系（小学校区、学校、保育園・幼稚園等、医療機関、福祉施設、図書館、市区町村役場及び集会施設等）は一般語なので法令典拠は不要です。国土数値情報は英語のデータセット名を公開していないため、当たる先もありません。
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ client.get_appraisal_reports(year=2024, area="13", division=UseDivision.INDUSTRI
 
 ### タイル座標だけで引くAPI
 
-タイル座標のみを取る11本は、引数が `z`, `x`, `y` だけです。
+タイル座標のみを取る12本は、引数が `z`, `x`, `y` だけです。
 
 | メソッド | ID | データ | ズーム |
 |---|---|---|---|
@@ -86,6 +86,7 @@ client.get_appraisal_reports(year=2024, area="13", division=UseDivision.INDUSTRI
 | `get_municipal_offices_and_public_meeting_facilities_etc` | XKT018 | 市区町村役場及び集会施設等 | 13〜15 |
 | `get_district_plans` | XKT023 | 地区計画 | 11〜15 |
 | `get_high_level_use_districts` | XKT024 | 高度利用地区 | 11〜15 |
+| `get_designated_emergency_evacuation_sites` | XGT001 | 指定緊急避難場所 | 11〜15 |
 
 ```python
 from pyreinfolib import tiles
@@ -126,6 +127,16 @@ client.get_welfare_facilities(
 ```
 
 コード表は[大分類](https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMajorClassificationCode.html)、[中分類](https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMiddleClassificationCode.html)、[小分類](https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMinorClassificationCode.html)にあります。enum ではなく `str` です。中分類62件・小分類122件という規模に加えて、大分類7件のうち2件に公表された英訳がないためです（[CONTRIBUTING.md](CONTRIBUTING.md#enum-にするか-str-にするか)）。
+
+### 自然公園地域
+
+`get_natural_park_areas`（XKT019）はズーム9〜15で、都道府県コードと地区コード（振興局区域）で絞り込めます。どちらも任意です。
+
+```python
+client.get_natural_park_areas(z=9, x=227, y=100, prefecture_code=["9", "11"])
+```
+
+**このAPIのコードは先頭の0を付けません。** 栃木県は `"9"` で、`"09"` ではありません。不動産取引価格情報の `area` は `"09"` の形式なので、同じ都道府県コードでも綴りが違います。マニュアルが定めている形式なので、`"09"` を渡すと `ValueError` になります。API に送ると認識されないコードとして空のタイルが返り、自然公園がないタイルと区別が付かなくなるためです。
 
 ## タイル座標
 

--- a/pyreinfolib/client.py
+++ b/pyreinfolib/client.py
@@ -62,6 +62,32 @@ def _join_codes(codes: Sequence[str] | str | None) -> str | None:
     return ",".join(codes)
 
 
+def _join_unpadded_codes(name: str, codes: Sequence[str] | str | None) -> str | None:
+    """Serialize codes the API documents without a leading zero, and refuse padded ones.
+
+    XKT019 asks for `9` where the price endpoints ask for `09` for the same prefecture: its
+    manual says to take the code from the published list and strip a leading zero. `09` is
+    therefore outside the documented format, and it is refused here rather than sent, because
+    a code the API does not recognise comes back as a tile with no features. That reads as
+    "no natural parks in this tile" rather than as an argument the API threw away.
+
+    Refused on the manual's word, not on observed behaviour, which is also how `z` is checked.
+    """
+    joined = _join_codes(codes)
+    if joined is None:
+        return None
+
+    padded = sorted({code for code in joined.split(",") if len(code) > 1 and code.startswith("0")})
+    if padded:
+        listed = ", ".join(padded)
+        raise ValueError(
+            f"`{name}` is written without a leading zero, so {listed} is not a code it takes. "
+            f"Drop the zero. Note that `area` on the other endpoints keeps it."
+        )
+
+    return joined
+
+
 def _compact(params: dict[str, Any]) -> dict[str, Any]:
     """Drop the arguments the caller left out, and refuse the ones left blank.
 
@@ -641,6 +667,49 @@ class Client:
         """
         return self._get_tile("XKT018", z, x, y, zoom_levels=range(13, 16))
 
+    def get_natural_park_areas(
+        self,
+        z: int,
+        x: int,
+        y: int,
+        prefecture_code: Sequence[str] | str | None = None,
+        district_code: Sequence[str] | str | None = None,
+    ) -> dict[str, Any]:
+        """Get natural park areas (自然公園地域).
+
+        Natural parks are national parks, quasi-national parks and prefectural natural parks,
+        each divided into special areas and ordinary areas.
+
+        Both filters here are written without a leading zero, unlike `area` elsewhere: this
+        endpoint asks for `9`, not `09`. A padded code raises `ValueError`.
+        See https://www.reinfolib.mlit.go.jp/help/apiManual/xkt019/ for details.
+        :param z: Zoom level (scale). 9 (prefecture) ~ 15 (detail)
+        :param x: x value of tile coordinates.
+        :param y: y value of tile coordinates.
+        :param prefecture_code: One prefecture code, or a sequence of them. 1 (Hokkaido) ~
+          47 (Okinawa), with no leading zero. See
+          https://nlftp.mlit.go.jp/ksj/gml/codelist/PrefCd.html
+          If not specified, the whole tile.
+        :param district_code: One subprefecture code, or a sequence of them, with no leading
+          zero. See https://nlftp.mlit.go.jp/ksj/gml/codelist/SubprefectureNameCd.html
+          If not specified, the whole tile.
+        :return: Natural park areas. (Response format: GeoJson)
+        :raises ValueError: If `z` is not between 9 and 15, or a code argument is empty or
+          carries a leading zero.
+        """
+        return self._get_tile(
+            "XKT019",
+            z,
+            x,
+            y,
+            {
+                "prefectureCode": _join_unpadded_codes("prefecture_code", prefecture_code),
+                "districtCode": _join_unpadded_codes("district_code", district_code),
+            },
+            # Wider than the rest, which start at 11.
+            zoom_levels=range(9, 16),
+        )
+
     def get_district_plans(self, z: int, x: int, y: int) -> dict[str, Any]:
         """Get district plans (地区計画).
         See https://www.reinfolib.mlit.go.jp/help/apiManual/xkt023/ for details.
@@ -662,3 +731,18 @@ class Client:
         :raises ValueError: If `z` is not between 11 and 15.
         """
         return self._get_tile("XKT024", z, x, y)
+
+    def get_designated_emergency_evacuation_sites(self, z: int, x: int, y: int) -> dict[str, Any]:
+        """Get designated emergency evacuation sites (指定緊急避難場所).
+
+        A designated emergency evacuation site is somewhere a municipality has designated for
+        people to withdraw to while a disaster is occurring or about to. It is not the same as
+        a designated shelter (指定避難所), which is where they stay afterwards.
+        See https://www.reinfolib.mlit.go.jp/help/apiManual/xgt001/ for details.
+        :param z: Zoom level (scale). 11 (city) ~ 15 (detail)
+        :param x: x value of tile coordinates.
+        :param y: y value of tile coordinates.
+        :return: Designated emergency evacuation sites. (Response format: GeoJson)
+        :raises ValueError: If `z` is not between 11 and 15.
+        """
+        return self._get_tile("XGT001", z, x, y)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -39,8 +39,9 @@ TILE_ENDPOINTS = [
     ("get_junior_high_school_districts", "XKT005", {}, range(11, 16)),
     ("get_welfare_facilities", "XKT011", {}, range(13, 16)),
     ("get_libraries", "XKT017", {}, range(13, 16)),
+    ("get_natural_park_areas", "XKT019", {}, range(9, 16)),
 ]
-TILE_ENDPOINT_IDS = ["XPT001", "XPT002", "XKT015", "XKT004", "XKT005", "XKT011", "XKT017"]
+TILE_ENDPOINT_IDS = ["XPT001", "XPT002", "XKT015", "XKT004", "XKT005", "XKT011", "XKT017", "XKT019"]
 
 # Tile endpoints whose only further parameters are optional filters, with the API's spelling
 # of the municipality code filter every one of them takes. Listed together because the filter
@@ -827,6 +828,16 @@ class TestBlankArguments:
                 {"z": 13, "x": 7312, "y": 3008, "welfare_facility_minor_class_code": []},
                 "welfareFacilityMinorClassCode",
             ),
+            (
+                "get_natural_park_areas",
+                {"z": 9, "x": 227, "y": 100, "prefecture_code": []},
+                "prefectureCode",
+            ),
+            (
+                "get_natural_park_areas",
+                {"z": 9, "x": 227, "y": 100, "district_code": []},
+                "districtCode",
+            ),
         ],
         ids=[
             "land_type_code",
@@ -835,6 +846,8 @@ class TestBlankArguments:
             "welfare_facility_class_code",
             "welfare_facility_middle_class_code",
             "welfare_facility_minor_class_code",
+            "prefecture_code",
+            "district_code",
         ],
     )
     def test_an_empty_sequence_of_codes_is_refused(self, mock_api, client, method_name, args, expected):
@@ -881,6 +894,7 @@ TILE_ONLY_ENDPOINTS = [
     ("get_municipal_offices_and_public_meeting_facilities_etc", "XKT018", range(13, 16)),
     ("get_district_plans", "XKT023", range(11, 16)),
     ("get_high_level_use_districts", "XKT024", range(11, 16)),
+    ("get_designated_emergency_evacuation_sites", "XGT001", range(11, 16)),
 ]
 TILE_ONLY_ENDPOINT_IDS = [endpoint for _, endpoint, _ in TILE_ONLY_ENDPOINTS]
 
@@ -1079,3 +1093,90 @@ class TestTileEndpointsWithOptionalFilters:
         assert getattr(client, method_name)(*tile) == DUMMY_RESPONSE
 
         assert params_of(mock_api.calls[0].request)["z"] == str(zoom)
+
+
+class TestUnpaddedCodes:
+    """XKT019 spells a prefecture `9` where the price endpoints spell it `09`.
+
+    Its manual says to take the code from the published list and remove a leading zero, so a
+    padded code is outside the documented format. It is refused locally for the same reason a
+    zoom level is: the API answers a code it does not recognise with a tile that has no
+    features, which is indistinguishable from a tile that genuinely has no natural parks.
+    """
+
+    def test_it_sends_the_codes_the_manual_documents(self, mock_api, client):
+        assert_request(
+            mock_api,
+            client.get_natural_park_areas,
+            "XKT019",
+            RequestCase(
+                id="both filters",
+                args={"z": 9, "x": 227, "y": 100, "prefecture_code": ["9", "11"], "district_code": "10"},
+                expected_params={
+                    "response_format": "geojson",
+                    "z": "9",
+                    "x": "227",
+                    "y": "100",
+                    "prefectureCode": "9,11",
+                    "districtCode": "10",
+                },
+            ),
+        )
+
+    def test_a_two_digit_code_without_padding_is_accepted(self, mock_api, client):
+        """Only a leading zero is refused. 47 is as valid as 9."""
+        assert_request(
+            mock_api,
+            client.get_natural_park_areas,
+            "XKT019",
+            RequestCase(
+                id="two digits",
+                args={"z": 9, "x": 227, "y": 100, "prefecture_code": "47"},
+                expected_params={
+                    "response_format": "geojson",
+                    "z": "9",
+                    "x": "227",
+                    "y": "100",
+                    "prefectureCode": "47",
+                },
+            ),
+        )
+
+    @pytest.mark.parametrize(
+        ("argument", "codes"),
+        [
+            ("prefecture_code", "09"),
+            ("prefecture_code", ["9", "01"]),
+            ("district_code", "01"),
+            ("district_code", ["01", "02"]),
+        ],
+        ids=["one prefecture", "one of several prefectures", "one district", "several districts"],
+    )
+    def test_a_padded_code_is_refused(self, mock_api, client, argument, codes):
+        """Nothing is registered on `mock_api`, so a padded code that slipped through would
+        fail as an unmatched request rather than as an empty tile.
+        """
+        with pytest.raises(ValueError, match=argument):
+            client.get_natural_park_areas(z=9, x=227, y=100, **{argument: codes})
+
+    def test_the_refusal_names_the_padded_code_and_says_what_to_do(self, mock_api, client):
+        """`area` keeps its leading zero, so being told to drop one needs the contrast."""
+        with pytest.raises(ValueError) as exc_info:
+            client.get_natural_park_areas(z=9, x=227, y=100, prefecture_code=["01", "9", "09"])
+
+        message = str(exc_info.value)
+        assert "01" in message
+        assert "09" in message
+        assert "area" in message
+
+    def test_a_single_digit_zero_is_not_treated_as_padding(self, mock_api, client):
+        """`0` is not a prefecture, but it is not a padded code either.
+
+        The check looks for a zero in front of something, so a bare `0` goes to the API and
+        is answered there rather than being reported as a padding mistake it is not.
+        """
+        mock_api.get(f"{BASE_URL}XKT019", json=DUMMY_RESPONSE)
+
+        client.get_natural_park_areas(z=9, x=227, y=100, prefecture_code="0")
+
+        assert params_of(mock_api.calls[0].request)["prefectureCode"] == "0"

--- a/tests/typing_usage.py
+++ b/tests/typing_usage.py
@@ -60,6 +60,8 @@ def tile_endpoints_from_a_point(client: Client) -> None:
     client.get_junior_high_school_districts(*tile)
     client.get_libraries(*tile)
     client.get_welfare_facilities(*tile)
+    client.get_natural_park_areas(*tile)
+    client.get_designated_emergency_evacuation_sites(*tile)
 
 
 def tile_endpoints_over_an_extent(client: Client) -> None:
@@ -136,6 +138,11 @@ def municipality_code_filters(client: Client) -> None:
         welfare_facility_middle_class_code="0101",
         welfare_facility_minor_class_code=["020101", "020102"],
     )
+
+    # XKT019 writes the same prefecture as `9` rather than `09`. Both filters are `str` like
+    # the rest, so the padding rule is a runtime check rather than something a type says.
+    client.get_natural_park_areas(z=9, x=227, y=100, prefecture_code="9")
+    client.get_natural_park_areas(z=9, x=227, y=100, prefecture_code=["9", "11"], district_code="10")
 
 
 def error_handling(client: Client) -> None:


### PR DESCRIPTION
The two endpoints left whose terms have a statutory translation. Every other unimplemented endpoint rests on an act the Japanese Law Translation database does not carry, so those need a source from the responsible ministry instead.

XKT019 writes a prefecture code without a leading zero, unlike `area` on the price endpoints. A padded code is refused locally, the same way an out-of-range zoom level is: the API answers a code it does not recognise with an empty tile, which reads as a tile with no natural parks in it.

## Changes

- `get_natural_park_areas` (XKT019, zoom 9-15, filters by prefecture and subprefecture)
- `get_designated_emergency_evacuation_sites` (XGT001, zoom 11-15)
- `_join_unpadded_codes`, which refuses a code carrying a leading zero
- Glossary entries for the natural park and evacuation terms
- Recorded which acts the translation database does not carry

## Notes

Not exercised against the live API. The zoom ranges match each endpoint's manual page, and 9-15 makes XKT019 the widest range so far.

Refusing `09` follows the manual, which says to take the code from the published list and drop a leading zero. Whether the API tolerates the padded form was not measured, so if it turns out to accept it, this rejects an input that would have worked.

Six acts turned out to be absent from the translation database: 水防法, 土砂災害防止法, 津波防災地域づくり法, 都市再生特別措置法, 地すべり等防止法, 急傾斜地法. That covers XKT003, XKT021, XKT022, XKT026 through XKT029. The absence is now written down in CONTRIBUTING.md so the check is not repeated.
