### PR TITLE
feat: add the disaster risk area, city planning road and DID endpoints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ squash merge のみを使います。リポジトリ設定が `squash_merge_comm
 
 API 名は外部にある唯一の安定した共有語彙です。利用者が読むのは MLIT のマニュアルであって、このライブラリのソースではありません。マニュアルの API 一覧を見ている人が対応するメソッドを推測できる状態に価値があります。
 
-公開APIは38本あります。読みやすさを基準にすると38回の裁量判断が必要で、必ず途中でぶれます。
+公開APIは35本あります。読みやすさを基準にすると35回の裁量判断が必要で、必ず途中でぶれます。
 
 API 側が改称したとき、追随すべきかの判断がつきます。
 
@@ -203,6 +203,14 @@ class PriceClassification(StrEnum):
 | 普通地域 | ordinary area | 自然公園法33条 |
 | 指定緊急避難場所 | designated emergency evacuation site | 災害対策基本法第7章2節、49条の4（[laws/view/4171](https://www.japaneselawtranslation.go.jp/ja/laws/view/4171/je)） |
 | 指定避難所 | designated shelter | 災害対策基本法49条の7 |
+| 災害危険区域 | disaster risk area | 建築基準法39条（[laws/view/4024](https://www.japaneselawtranslation.go.jp/ja/laws/view/4024/je)） |
+| 都市計画施設 | city planning facility | 都市計画法4条6項 |
+| 都市計画事業 | city planning project | 都市計画法4条15項 |
+| 都市施設 | urban facility | 都市計画法4条5項 |
+| 都市計画道路 | city planning road | 都市計画法に定義なし。下記の通り合成 |
+| 人口集中地区 | densely inhabited district | [総務省統計局 英語ページ](https://www.stat.go.jp/english/data/jyutaku/25021.html) |
+
+**都市計画道路は合成した訳語です。** 都市計画法は 都市計画道路 を定義しておらず、都市計画施設として定められた道路の通称です。同法の訳が 都市計画施設 を `city planning facility`、都市計画事業 を `city planning project` としているので、`city planning` + 名詞 は同法自身の造語パターンです。道路 は11条1項1号の都市施設の一覧で `roads` です。12条の11には `roads that are city planning facilities` という言い方も出てきます。
 
 MLIT 用語集は `Land （Market） Value` と括弧付きで記載していますが、識別子に括弧は使えず、[MLIT の英語ページ](https://www.mlit.go.jp/en/totikensangyo/totikensangyo_fr4_000001.html)が括弧なしで運用しているため、括弧を外した形を採用します。
 
@@ -228,8 +236,7 @@ MLIT 用語集は `Land （Market） Value` と括弧付きで記載していま
 | 用語 | 典拠を探す先 | 用途 |
 |---|---|---|
 | 立地適正化計画 | 都市再生特別措置法（法令訳DBに収録なし） | XKT003 |
-| 災害危険区域 | 建築基準法39条 | XKT016 |
-| 大規模盛土造成地 | 国土交通省 | XKT020 |
+| 大規模盛土造成地マップ | 国土交通省 | XKT020 |
 | 地すべり防止区域 | 地すべり等防止法（法令訳DBに収録なし） | XKT021 |
 | 急傾斜地崩壊危険区域 | 急傾斜地法（法令訳DBに収録なし） | XKT022 |
 | 地形区分に基づく液状化の発生傾向図 | 国土交通省都市局 | XKT025 |
@@ -237,8 +244,6 @@ MLIT 用語集は `Land （Market） Value` と括弧付きで記載していま
 | 高潮浸水想定区域 | 水防法（法令訳DBに収録なし） | XKT027 |
 | 津波浸水想定 | 津波防災地域づくり法（法令訳DBに収録なし） | XKT028 |
 | 土砂災害警戒区域 | 土砂災害防止法（法令訳DBに収録なし） | XKT029 |
-| 都市計画道路 | 都市計画法（簡潔な定訳がなく判断が必要） | XKT030 |
-| 人口集中地区 | 総務省統計局（国勢調査英語版で Densely Inhabited District / DID が定着） | XKT031 |
 | 災害履歴 | 国土調査（土地履歴調査） | XST001 |
 
 **「法令訳DBに収録なし」は確認済みです。** 法令検索で法令名を引いて0件でした。優先順位1が使えないので、これらは3（所管省庁の英語版資料）に降りることになります。同じ確認を繰り返さないよう結果を残しています。

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ client.get_appraisal_reports(year=2024, area="13", division=UseDivision.INDUSTRI
 
 ### タイル座標だけで引くAPI
 
-タイル座標のみを取る12本は、引数が `z`, `x`, `y` だけです。
+タイル座標のみを取る13本は、引数が `z`, `x`, `y` だけです。
 
 | メソッド | ID | データ | ズーム |
 |---|---|---|---|
@@ -86,6 +86,7 @@ client.get_appraisal_reports(year=2024, area="13", division=UseDivision.INDUSTRI
 | `get_municipal_offices_and_public_meeting_facilities_etc` | XKT018 | 市区町村役場及び集会施設等 | 13〜15 |
 | `get_district_plans` | XKT023 | 地区計画 | 11〜15 |
 | `get_high_level_use_districts` | XKT024 | 高度利用地区 | 11〜15 |
+| `get_city_planning_roads` | XKT030 | 都市計画道路 | 11〜15 |
 | `get_designated_emergency_evacuation_sites` | XGT001 | 指定緊急避難場所 | 11〜15 |
 
 ```python
@@ -96,14 +97,18 @@ client.get_use_districts(*tiles.containing(lon=139.7016, lat=35.6580, z=15))
 
 ### 行政区域コードで絞り込めるAPI
 
-次の4本はタイル座標に加えて `administrative_area_code`（行政区域コード、5桁）を取ります。**任意**なので、省略すればタイル全体が返ります。
+次の6本はタイル座標に加えて `administrative_area_code`（行政区域コード、5桁）を取ります。**任意**なので、省略すればタイル全体が返ります。
 
 | メソッド | ID | データ | ズーム |
 |---|---|---|---|
 | `get_elementary_school_districts` | XKT004 | 小学校区 | 11〜15 |
 | `get_junior_high_school_districts` | XKT005 | 中学校区 | 11〜15 |
 | `get_welfare_facilities` | XKT011 | 福祉施設 | 13〜15 |
+| `get_disaster_risk_areas` | XKT016 | 災害危険区域 | 11〜15 |
 | `get_libraries` | XKT017 | 図書館 | 13〜15 |
+| `get_densely_inhabited_districts` | XKT031 | 人口集中地区 | 9〜15 |
+
+`get_disaster_risk_areas` のコードは**代表**行政コードです。複数の市区町村にまたがる区域には、そのうち1つのコードしか付きません。
 
 ```python
 client.get_libraries(*tiles.containing(lon=139.7016, lat=35.6580, z=15))

--- a/pyreinfolib/client.py
+++ b/pyreinfolib/client.py
@@ -241,9 +241,9 @@ class Client:
         `params` is passed as a dict rather than as keyword arguments because two of the
         keys the API expects, `from` and `to`, are Python keywords.
 
-        The zoom level is checked here rather than in each public method. There are 33 tile
-        endpoints to add, and a check that lives in the shared helper cannot be left out of
-        one of them.
+        The zoom level is checked here rather than in each public method. 32 of the API's 35
+        endpoints are addressed by tile, and a check that lives in the shared helper cannot be
+        left out of one of them.
 
         :param endpoint: Endpoint id, e.g. `XKT015`.
         :param z: Zoom level (scale).
@@ -627,6 +627,40 @@ class Client:
         """
         return self._get_tile("XKT015", z, x, y)
 
+    def get_disaster_risk_areas(
+        self,
+        z: int,
+        x: int,
+        y: int,
+        administrative_area_code: Sequence[str] | str | None = None,
+    ) -> dict[str, Any]:
+        """Get disaster risk areas (災害危険区域).
+
+        A disaster risk area is one a local government has designated by ordinance as
+        frequently endangered by tidal waves, high tide or flooding, and where it therefore
+        restricts building.
+        See https://www.reinfolib.mlit.go.jp/help/apiManual/xkt016/ for details.
+        :param z: Zoom level (scale). 11 (city) ~ 15 (detail)
+        :param x: x value of tile coordinates.
+        :param y: y value of tile coordinates.
+        :param administrative_area_code: One municipality code, or a sequence of them.
+          Format: NNNNN. The same code table the price endpoints spell `city`.
+          Note that this endpoint documents it as the *representative* municipality of an
+          area, so an area spanning several municipalities carries only one of them.
+          See https://nlftp.mlit.go.jp/ksj/gml/codelist/AdminiBoundary_CD.xlsx
+          If not specified, the whole tile.
+        :return: Disaster risk areas. (Response format: GeoJson)
+        :raises ValueError: If `z` is not between 11 and 15, or `administrative_area_code`
+          is empty.
+        """
+        return self._get_tile(
+            "XKT016",
+            z,
+            x,
+            y,
+            {"administrativeAreaCode": _join_codes(administrative_area_code)},
+        )
+
     def get_libraries(
         self,
         z: int,
@@ -731,6 +765,58 @@ class Client:
         :raises ValueError: If `z` is not between 11 and 15.
         """
         return self._get_tile("XKT024", z, x, y)
+
+    def get_city_planning_roads(self, z: int, x: int, y: int) -> dict[str, Any]:
+        """Get city planning roads (都市計画道路).
+
+        `city planning road` is composed rather than quoted. The City Planning Act does not
+        define 都市計画道路; it is the common name for a road determined as a city planning
+        facility, which the Act's translation renders as "roads that are city planning
+        facilities". Both halves come from that translation -- 都市計画施設 is `city planning
+        facility` and 都市計画事業 is `city planning project`, so `city planning` plus the noun
+        is the Act's own pattern, and 道路 is `roads` in the list of urban facilities.
+        See https://www.reinfolib.mlit.go.jp/help/apiManual/xkt030/ for details.
+        :param z: Zoom level (scale). 11 (city) ~ 15 (detail)
+        :param x: x value of tile coordinates.
+        :param y: y value of tile coordinates.
+        :return: City planning roads. (Response format: GeoJson)
+        :raises ValueError: If `z` is not between 11 and 15.
+        """
+        return self._get_tile("XKT030", z, x, y)
+
+    def get_densely_inhabited_districts(
+        self,
+        z: int,
+        x: int,
+        y: int,
+        administrative_area_code: Sequence[str] | str | None = None,
+    ) -> dict[str, Any]:
+        """Get densely inhabited districts (人口集中地区).
+
+        A densely inhabited district, or DID, is a statistical area set by the population
+        census: contiguous basic unit blocks each holding about 4,000 inhabitants or more per
+        square kilometre, totalling over 5,000 people.
+        See https://www.reinfolib.mlit.go.jp/help/apiManual/xkt031/ for details.
+        :param z: Zoom level (scale). 9 (prefecture) ~ 15 (detail)
+        :param x: x value of tile coordinates.
+        :param y: y value of tile coordinates.
+        :param administrative_area_code: One municipality code, or a sequence of them.
+          Format: NNNNN. The same code table the price endpoints spell `city`.
+          See https://nlftp.mlit.go.jp/ksj/gml/codelist/AdminiBoundary_CD.xlsx
+          If not specified, the whole tile.
+        :return: Densely inhabited districts. (Response format: GeoJson)
+        :raises ValueError: If `z` is not between 9 and 15, or `administrative_area_code`
+          is empty.
+        """
+        return self._get_tile(
+            "XKT031",
+            z,
+            x,
+            y,
+            {"administrativeAreaCode": _join_codes(administrative_area_code)},
+            # Wider than the rest, which start at 11. XKT019 is the other one.
+            zoom_levels=range(9, 16),
+        )
 
     def get_designated_emergency_evacuation_sites(self, z: int, x: int, y: int) -> dict[str, Any]:
         """Get designated emergency evacuation sites (指定緊急避難場所).

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -40,8 +40,21 @@ TILE_ENDPOINTS = [
     ("get_welfare_facilities", "XKT011", {}, range(13, 16)),
     ("get_libraries", "XKT017", {}, range(13, 16)),
     ("get_natural_park_areas", "XKT019", {}, range(9, 16)),
+    ("get_disaster_risk_areas", "XKT016", {}, range(11, 16)),
+    ("get_densely_inhabited_districts", "XKT031", {}, range(9, 16)),
 ]
-TILE_ENDPOINT_IDS = ["XPT001", "XPT002", "XKT015", "XKT004", "XKT005", "XKT011", "XKT017", "XKT019"]
+TILE_ENDPOINT_IDS = [
+    "XPT001",
+    "XPT002",
+    "XKT015",
+    "XKT004",
+    "XKT005",
+    "XKT011",
+    "XKT017",
+    "XKT019",
+    "XKT016",
+    "XKT031",
+]
 
 # Tile endpoints whose only further parameters are optional filters, with the API's spelling
 # of the municipality code filter every one of them takes. Listed together because the filter
@@ -51,6 +64,8 @@ FILTERED_TILE_ENDPOINTS = [
     ("get_junior_high_school_districts", "XKT005", 11),
     ("get_welfare_facilities", "XKT011", 13),
     ("get_libraries", "XKT017", 13),
+    ("get_disaster_risk_areas", "XKT016", 11),
+    ("get_densely_inhabited_districts", "XKT031", 9),
 ]
 FILTERED_TILE_ENDPOINT_IDS = [endpoint for _, endpoint, _ in FILTERED_TILE_ENDPOINTS]
 
@@ -702,8 +717,8 @@ class TestClient:
             client.get_land_market_value_publication_and_research_point(z=z, x=7312, y=3008, year=2020)
 
     def test_the_rejection_names_the_endpoint_and_the_range(self, mock_api, client):
-        """With 33 tile endpoints and more than one range among them, "z must be 11 to 15" on
-        its own does not tell the caller which endpoint disagreed.
+        """With 32 tile endpoints and four ranges among them, "z must be 11 to 15" on its own
+        does not tell the caller which endpoint disagreed.
         """
         with pytest.raises(ValueError) as exc_info:
             client.get_land_market_value_publication_and_research_point(z=11, x=7312, y=3008, year=2020)
@@ -838,6 +853,11 @@ class TestBlankArguments:
                 {"z": 9, "x": 227, "y": 100, "district_code": []},
                 "districtCode",
             ),
+            (
+                "get_densely_inhabited_districts",
+                {"z": 9, "x": 227, "y": 100, "administrative_area_code": []},
+                "administrativeAreaCode",
+            ),
         ],
         ids=[
             "land_type_code",
@@ -848,6 +868,7 @@ class TestBlankArguments:
             "welfare_facility_minor_class_code",
             "prefecture_code",
             "district_code",
+            "administrative_area_code on the widest zoom range",
         ],
     )
     def test_an_empty_sequence_of_codes_is_refused(self, mock_api, client, method_name, args, expected):
@@ -894,6 +915,7 @@ TILE_ONLY_ENDPOINTS = [
     ("get_municipal_offices_and_public_meeting_facilities_etc", "XKT018", range(13, 16)),
     ("get_district_plans", "XKT023", range(11, 16)),
     ("get_high_level_use_districts", "XKT024", range(11, 16)),
+    ("get_city_planning_roads", "XKT030", range(11, 16)),
     ("get_designated_emergency_evacuation_sites", "XGT001", range(11, 16)),
 ]
 TILE_ONLY_ENDPOINT_IDS = [endpoint for _, endpoint, _ in TILE_ONLY_ENDPOINTS]

--- a/tests/typing_usage.py
+++ b/tests/typing_usage.py
@@ -62,6 +62,9 @@ def tile_endpoints_from_a_point(client: Client) -> None:
     client.get_welfare_facilities(*tile)
     client.get_natural_park_areas(*tile)
     client.get_designated_emergency_evacuation_sites(*tile)
+    client.get_disaster_risk_areas(*tile)
+    client.get_densely_inhabited_districts(*tile)
+    client.get_city_planning_roads(*tile)
 
 
 def tile_endpoints_over_an_extent(client: Client) -> None:
@@ -129,6 +132,8 @@ def municipality_code_filters(client: Client) -> None:
     client.get_elementary_school_districts(z=11, x=1819, y=806, administrative_area_code="13102")
     client.get_junior_high_school_districts(z=11, x=1819, y=806, administrative_area_code=["01101", "13102"])
     client.get_libraries(z=13, x=7312, y=3008, administrative_area_code="13102")
+    client.get_disaster_risk_areas(z=11, x=1819, y=806, administrative_area_code="13102")
+    client.get_densely_inhabited_districts(z=9, x=227, y=100, administrative_area_code=["01101", "13102"])
     client.get_welfare_facilities(
         z=13,
         x=7312,


### PR DESCRIPTION
Three endpoints whose terms have a source. That leaves ten, all of which need a source from the responsible ministry because the acts they rest on are absent from the Japanese Law Translation database.

`city planning road` is the one composed name here. The City Planning Act does not define 都市計画道路, so it is built from parts that are in the Act's translation rather than taken whole.

## Changes

- `get_disaster_risk_areas` (XKT016, zoom 11-15, filters by municipality)
- `get_city_planning_roads` (XKT030, zoom 11-15)
- `get_densely_inhabited_districts` (XKT031, zoom 9-15, filters by municipality)
- Glossary entries for these three, plus the city planning terms the composition rests on
- Corrected the endpoint counts cited in three places

## Notes

Not exercised against the live API. The zoom ranges match each endpoint's manual page.

The counts said 38 endpoints and 33 tile endpoints. Both are wrong: the manual publishes 35, and 32 of those take tile coordinates. XKT008, XKT009 and XKT012 look like they should exist from the numbering, but they are absent from the manual index and their pages return 404. The 38 was cited as the reason the naming rules avoid case-by-case judgement, so the number carries an argument rather than being decoration.

XKT016 documents its filter as the *representative* municipality of an area, unlike the other five endpoints that take `administrativeAreaCode`. An area spanning several municipalities carries one code, so filtering by municipality can miss areas that reach into it.

XKT020's full name turned out to be 大規模盛土造成地マップ, with マップ on the end. Corrected in the glossary so the derivation starts from the real name. Whether マップ is a formulaic word to drop is left for when that endpoint is added.
