### PR TITLE
docs: split the glossary into its own file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,7 @@
 # Contributing
 
+訳語と典拠は [GLOSSARY.md](GLOSSARY.md) にあります。
+
 ## 開発環境
 
 ```shell
@@ -42,7 +44,7 @@ squash merge のみを使います。リポジトリ設定が `squash_merge_comm
 
 - タイトルは [Conventional Commits](https://www.conventionalcommits.org/) 準拠。`.github/workflows/pr-title.yml` が検証します
 - release-please がタイトルからバージョンと CHANGELOG を生成します。`feat` は minor、`fix` は patch、`!` 付きは破壊的変更（1.0 到達前は minor）
-- 破壊的変更は説明文の末尾に `BREAKING CHANGE: <移行手順>` のフッタを書いてください。CHANGELOG の BREAKING CHANGES に載ります
+- 破壊的変更は[説明文にフッタを書いてください](#破壊的変更は-breaking-change-を-pr-本文に書いてください)
 - 説明文が git 履歴に残るため、レビュー用のチェックリストや議論の経緯は書かないでください
 
 ### 説明文の書式
@@ -56,17 +58,25 @@ squash merge のみを使います。リポジトリ設定が `squash_merge_comm
 
 テンプレートは置いていません。`PR_BODY` 設定では雛形がそのままコミットメッセージに残り、`--body-file` や Dependabot、release-please には届かないためです。
 
+### 破壊的変更は `BREAKING CHANGE:` を PR 本文に書いてください
+
+```
+BREAKING CHANGE: `get_old_name` is now `get_new_name`. ...
+```
+
+**ローカルのコミットメッセージに書いても届きません。** マージコミットの本文は PR 本文になり、ローカルのコミットメッセージは捨てられます。
+
+タイトルの `feat!:` は版数を上げるのに足ります。しかし**移行方法は本文のフッタにしか書けません**。フッタがないと CHANGELOG と GitHub Release のノートに subject 行だけが載り、利用者は何が何に変わったか分かりません。0.7.0 で実際に起きました（#69）。
+
+**リリース PR を直す場合は、マージ前に CHANGELOG とリリース PR 本文の両方を直してください。** main に別のコミットが入ると release-please がどちらも作り直します。
+
 ## 命名
 
-メソッド名・引数名・enum 名は、**不動産情報ライブラリの[API操作説明](https://www.reinfolib.mlit.go.jp/help/apiManual/)に載っている API 名から機械的に導出します**。読みやすさを基準に選びません。
+メソッド名・引数名・enum 名は、**不動産情報ライブラリの[API操作説明](https://www.reinfolib.mlit.go.jp/help/apiManual/)に載っている API 名から機械的に導出します**。読みやすさを基準に選びません。理由は3つあります。
 
-理由は3つあります。
-
-API 名は外部にある唯一の安定した共有語彙です。利用者が読むのは MLIT のマニュアルであって、このライブラリのソースではありません。マニュアルの API 一覧を見ている人が対応するメソッドを推測できる状態に価値があります。
-
-公開APIは35本あります。読みやすさを基準にすると35回の裁量判断が必要で、必ず途中でぶれます。
-
-API 側が改称したとき、追随すべきかの判断がつきます。
+- API 名は外部にある唯一の安定した共有語彙です。利用者が読むのは MLIT のマニュアルであって、このライブラリのソースではありません。マニュアルの API 一覧を見ている人が対応するメソッドを推測できる状態に価値があります
+- 公開APIは35本あります。読みやすさを基準にすると35回の裁量判断が必要で、必ず途中でぶれます
+- API 側が改称したとき、追随すべきかの判断がつきます
 
 ### 導出手順
 
@@ -74,14 +84,14 @@ API 側が改称したとき、追随すべきかの判断がつきます。
 2. **出典を落とす。** 国土数値情報、都市計画決定GISデータ、国土地理院GISデータ、国土調査、国土交通省都市局は、誰が公開したデータかを示すもので、何のデータかを示していない
 3. **主題を言い換えただけの括弧を落とす。** 不動産価格（取引価格・成約価格）の括弧は 不動産価格 の内訳なので落とす
 4. **括弧の中身がデータセット名なら残す。** 出典が主題の位置に来ている場合（手順2で頭を落とした場合）はこちら。国土数値情報（駅別乗降客数）→ 駅別乗降客数
-5. **括弧の中身がデータの限定なら残す。** 洪水浸水想定区域（想定最大規模）→ `expected_flood_inundation_areas_at_maximum_scale`。手順3の言い換えでも手順4のデータセット名でもなく、同名のデータのうちどれかを絞る語です。落とすと何が返るか名前から分からなくなります。**何が返らないかを docstring に書いてください。** XKT026 なら 計画規模 の方が返らないことです
-6. **定型辞を落とす。** 情報、取得、一覧、API、マップ。マップ を落とすのは、返るのが地図ではなく地物だからです。XKT020 の原典データ名は 大規模盛土造成地**データ** でマップが付かず、土地白書の英語版も `large-scale developed embankment` を対象、`map of ...` を公表物として書き分けています
+5. **括弧の中身がデータの限定なら残す。** 洪水浸水想定区域（想定最大規模）→ `expected_flood_inundation_areas_at_maximum_scale`。同名のデータのうちどれかを絞る語なので、落とすと何が返るか名前から分からなくなります。**何が返らないかを docstring に書いてください。** XKT026 なら 計画規模 の方です
+6. **定型辞を落とす。** 情報、取得、一覧、API、マップ。マップ を落とすのは、返るのが地図ではなく地物だからです。XKT020 の原典データ名は 大規模盛土造成地**データ** で、土地白書の英語版も `large-scale developed embankment` を対象、`map of ...` を公表物として書き分けています
 7. **引数で表現されている限定を落とす。** 都道府県内市区町村一覧 の 都道府県内 は `area` 引数が表すので落とす。手順5との違いは引数の有無です。XKT026 に 想定最大規模 を選ぶ引数はないので、名前でしか区別できません
 8. **トップレベルの「・」は `and` として残す。** 地価公示・地価調査 はどちらも独立したデータセットなので両方残す。手順3の括弧内の「・」とは違う。共通する語をまとめるかどうかは典拠を見て決めます
-   - **典拠に並列形があればそのまま使う。** 防火・準防火地域 は建築基準法第5節の節名が `Fire Prevention Districts and Quasi-fire Prevention Districts` で、日本語が1回しか書いていない「地域」を2回書いています。`Fire Prevention District` が定義語なので、分解せず文字列のまま保ちます。検索でも届きます
-   - **典拠に並列形がなければ共通部分をまとめてよい。** 地価公示・地価調査 は並列形の公式訳がなく、組織名（地価公示室 / 地価調査課）の完全形から `land_market_value_publication_and_research` を導いています
+   - **典拠に並列形があればそのまま使う。** 防火・準防火地域 は建築基準法第5節の節名が `Fire Prevention Districts and Quasi-fire Prevention Districts` で、日本語が1回しか書いていない「地域」を2回書いています。`Fire Prevention District` が定義語なので、分解せず保ちます
+   - **典拠に並列形がなければ共通部分をまとめてよい。** 地価公示・地価調査 は並列形の公式訳がなく、組織名の完全形から `land_market_value_publication_and_research` を導いています
 9. **「ポイント (点)」は `_point` として残す。** XPT001 と XPT002 だけが持つ
-10. 残った語を用語集で訳す
+10. 残った語を [GLOSSARY.md](GLOSSARY.md) で訳す
 11. **同じ語が2回出てきたら、訳は1回でよい。** 洪水浸水想定区域（想定最大規模）は 想定 を2回含みますが `expected` は1回です。手順8の「典拠に並列形がなければまとめてよい」と同じ扱いで、doubled form に典拠がないためです
 12. `get_` を付ける
 
@@ -98,20 +108,30 @@ API 側が改称したとき、追随すべきかの判断がつきます。
 
 ### 引数名は API のパラメータ名を snake_case にしただけにします
 
-`administrativeAreaCode` → `administrative_area_code`、`welfareFacilityMiddleClassCode` → `welfare_facility_middle_class_code` です。メソッド名と違って導出手順はありません。
+`administrativeAreaCode` → `administrative_area_code`、`welfareFacilityMiddleClassCode` → `welfare_facility_middle_class_code` です。メソッド名と違って導出手順はありません。**API の綴りを直しません。** XST001 の `disastertype_code` は `disaster` の後にアンダースコアが入らないままです。
 
 **同じコード表でも API の綴りが違えば引数名も分けます。** 市区町村コードは XIT001 では `city`、XKT004 などでは `administrativeAreaCode` です。同じ5桁のコード表ですが、片方に寄せると寄せなかった側の引数名が、利用者がマニュアルで読むパラメータ名と一致しなくなります。docstring で同じコード表だと伝えます。
 
 例外は Python の予約語と衝突する場合です。XPT001 の `from` / `to` は `period_from` / `period_to` にしています。
 
+### 「等」は `_ETC` にします
+
+`LandTypeCode.PRE_OWNED_CONDOMINIUMS_ETC`（中古マンション等）が先例です。メソッド名でも同じで、保育園・幼稚園**等** → `get_nursery_schools_and_kindergartens_etc`。
+
+### API 名と公定訳が食い違うときは API 名に従います
+
+XKT021 のデータセット名は 地すべり防止**地区** ですが、実体は地すべり等防止法3条の 地すべり防止**区域** で、公定訳は `landslide prevention area` です。メソッド名は `get_landslide_prevention_districts` にしています。
+
+利用者が読むのは MLIT のマニュアルなので、マニュアルの語からメソッドに辿り着ける方を採ります。**食い違いは docstring に1文で書いてください。** 書かないと、公定訳を知っている利用者が `districts` を訳し間違いと受け取ります。
+
 ### 導出例
 
-規則が既存の6メソッドを再現することを確認済みです。
+規則が非タイル系とポイント系の6本を再現することを確認済みです。
 
 | ID | API 名 | 落とした部分 | メソッド名 |
 |---|---|---|---|
 | XIT001 | 不動産価格（取引価格・成約価格）情報取得API | 括弧（手順3）、情報取得 | `get_real_estate_prices` |
-| XIT002 | 都道府県内市区町村一覧取得API | 都道府県内（手順6）、一覧取得 | `get_municipalities` |
+| XIT002 | 都道府県内市区町村一覧取得API | 都道府県内（手順7）、一覧取得 | `get_municipalities` |
 | XCT001 | 鑑定評価書情報API | 情報 | `get_appraisal_reports` |
 | XPT001 | 不動産価格（取引価格・成約価格）情報のポイント (点) API | 括弧（手順3）、情報 | `get_real_estate_prices_point` |
 | XPT002 | 地価公示・地価調査のポイント (点) API | なし | `get_land_market_value_publication_and_research_point` |
@@ -127,7 +147,7 @@ API 側が改称したとき、追随すべきかの判断がつきます。
 | `Properties` | タイル系の1フィーチャの `properties` | `UseDistrictsProperties` |
 | `Item` | 非タイル系の `data` の1要素 | `RealEstatePricesItem` |
 
-**単数化しません。** 1フィーチャを表す型なので意味的には単数が正しいのですが、`get_nursery_schools_and_kindergartens_etc` や `get_fire_prevention_districts_and_quasi_fire_prevention_districts` のような並列名を単数化すると `and` を `or` に変えるかどうかから判断が始まります。[長さは基準にしません](#長さは基準にしません)と同じ理由で、裁量が入る余地を作らない方を採ります。接尾辞が「1件分」を担っています。
+**単数化しません。** 1フィーチャを表す型なので意味的には単数が正しいのですが、`get_nursery_schools_and_kindergartens_etc` のような並列名を単数化すると `and` を `or` に変えるかどうかから判断が始まります。[長さは基準にしません](#長さは基準にしません)と同じ理由で、裁量が入る余地を作らない方を採ります。接尾辞が「1件分」を担っています。
 
 この対応は `tests/test_types.py` が実行時に検証します。メソッドを追加して型を付け忘れる、あるいは隣のエンドポイントの型を貼ってしまう、というのはどちらも `ruff` と `ty` と `test_client.py` を通ってしまうためです。
 
@@ -137,7 +157,7 @@ API 側が改称したとき、追随すべきかの判断がつきます。
 
 **コードそれ自体に意味が読み取れないものは enum にします。** `"02"` は 成約価格情報 を意味しますが、呼び出し側からは何も読み取れません。
 
-**値に意味が読み取れるものは `Literal` のままにします。** `quarter: Literal[1, 2, 3, 4]`、`language: Literal["ja", "en"]`、`z: Literal[11, 12, 13, 14, 15]` はそのままで十分です。
+**値に意味が読み取れるものは `Literal` のままにします。** `quarter: Literal[1, 2, 3, 4]`、`language: Literal["ja", "en"]` はそのままで十分です。
 
 `StrEnum` を使います。実行時は文字列としても動くので、型チェックだけが新しい制約になります。
 
@@ -148,7 +168,7 @@ API 側が改称したとき、追随すべきかの判断がつきます。
 - **数えられる規模である。** `UseDivision` は8件、`LandTypeCode` は5件です。都道府県コード（47件）と市区町村コード（約1900件）は `area`、`city`、`administrative_area_code` として `str` のままにし、docstring にコード表の URL を置いています
 - **全メンバーに典拠のある訳語がある。** 一部しか訳せないコード表は enum にしません。呼び出し側が同じ引数に enum メンバーと生の文字列を混ぜることになり、enum を作った意味がなくなります
 
-福祉施設大分類コード（XKT011）が2つ目に当たる例です。7件で規模は足りていますが、うち2件に公表された英訳がありません。
+2つ目に当たる例が2つあります。**福祉施設大分類コード（XKT011）** は7件で規模は足りていますが、うち2件に公表された英訳がありません。**災害分類コード（XST001）** は12件のうち4件（河道閉塞、津波高、浸水域、地震土砂災害）に典拠がありません。
 
 | コード | 用語 | 英訳 | 典拠 |
 |---|---|---|---|
@@ -170,7 +190,7 @@ API が同じパラメータ名を使っていても、コード表が違えば�
 
 ### メンバー名
 
-用語集で訳し、日本語のコード表記をコメントで添えます。
+[GLOSSARY.md](GLOSSARY.md) で訳し、日本語のコード表記をコメントで添えます。
 
 ```python
 @unique
@@ -188,7 +208,7 @@ class PriceClassification(StrEnum):
 
 ### キーは API のタグ名をそのまま使います
 
-各エンドポイントのマニュアル個別ページに `＜出力＞` の表があり、その **タグ名** の列が JSON のキーです。**整えずにそのまま写します。** 用語集は使いません。ここは訳す場所ではないからです。
+各エンドポイントのマニュアル個別ページに `＜出力＞` の表があり、その **タグ名** の列が JSON のキーです。**整えずにそのまま写します。** GLOSSARY.md は使いません。ここは訳す場所ではないからです。
 
 結果として API 側の不統一が全部入ってきます。
 
@@ -254,7 +274,7 @@ APIキーが手元にあるときに、この順で確認してください。�
 | 確認すること | 叩くもの | 違っていた場合 |
 |---|---|---|
 | XCT001 のキーが本当に日本語（U+3000 込み）か | `get_appraisal_reports` | `AppraisalReportsItem` の109キーを全面差し替え。**最も影響が大きい** |
-| `proximity_to_transportation_facilitites` が本当に綴り違いのままか | `get_land_market_value_publication_and_research_point` | 型と、`types.py` / CONTRIBUTING / README の3箇所の記述を直す |
+| `proximity_to_transportation_facilitites` が本当に綴り違いのままか | `get_land_market_value_publication_and_research_point` | 型と、`types.py` / このファイル / README の3箇所の記述を直す |
 | `DataResponse` の封筒が `status` / `data` か、`status` が `"OK"` 以外を取るか | 非タイル系のどれか | マニュアルに記載がない部分。取らないなら `Literal["OK"]` に締められる |
 | 整数型・実数型・真偽型のフィールドが `null` で来ることがあるか | 全般。XKT013 の `GASSAN20XX` はデータ例が空 | `\| None` へ広げる。**読み取り側にとって破壊的** なので、ここだけは実物を見ないと動かせない |
 | キーが省略されるのか空文字で来るのか | `get_real_estate_prices` で農地・林地と中古マンションを比べる | 常に来るキーは `total=False` から必須に締められる（非破壊） |
@@ -264,223 +284,21 @@ APIキーが手元にあるときに、この順で確認してください。�
 
 締める方向（`total=False` → 必須、合併型を狭める、`Literal` にする）は読み取り側にとって非破壊です。広げる方向（`None` を足す）は破壊的なので、`feat!:` が必要になります。
 
-## 用語集
+## API の癖
 
-### 典拠の優先順位
-
-1. **[日本法令外国語訳データベースシステム](https://www.japaneselawtranslation.go.jp/)**（法務省）。今回必要な語の多くは法令用語で、政府公式訳が条文単位で日英対応しています
-2. **[地価に関する国際的な情報発信の強化に向けた検討業務 調査報告書](https://www.mlit.go.jp/common/000214955.pdf)**（国土交通省 土地・建設産業局、平成24年3月）。地価公示・鑑定評価の語彙について、MLIT が統一的な英訳を提示する目的で作成した用語集です。地価関連語は法令訳DBより詳しく、DBの訳に対する明示的な注記もあります
-3. **所管省庁の英語版資料**。法令用語でないもの（統計用語、データセット名）。[土地白書の英語版](https://www.mlit.go.jp/totikensangyo/content/001428844.pdf)（国土交通省 土地・建設産業局）は宅地・防災系の語が載っていて当たり所です。大規模盛土造成地 はここで確定しました
-4. **既にこのライブラリで使っている訳語**。1〜3で確認できないもの
-
-### 優先順位のどこにも訳語がないとき
-
-根拠法が法令訳DBに未収録で、所管省庁の英語資料も旧称のまま揺れている語があります。**どの段階でも訳語を発明しないでください。** 次の順に試します。
-
-1. **その語を名前にしない設計を選ぶ。** コード表なら `str` のままにできます（[enum にするか `str` にするか](#enum-にするか-str-にするか)）。メソッド名は避けようがないので、この手は使えません
-2. **典拠のある部品から合成する。** 根拠法自身の造語パターンに従ってください。都市計画道路 は同法の 都市計画施設 = `city planning facility`、都市計画事業 = `city planning project` というパターンに、11条1項1号の 道路 = `roads` を入れて `city planning road` としています。部品のどちらかに典拠がなければ使えません
-3. **二次資料で定着している訳語を採る。** 政府資料が原典として挙げられていて、かつ競合候補がない場合に限ります。立地適正化計画 = `location normalization plan` がこれです
-4. **実装を保留する。** 上のどれも使えないとき
-
-**どの段階で決めたか、そして空振りした当たり先を用語集に書いてください。** 原典が後から出てきたときに見直せます。当たり先を書き残さないと、次の人が同じ検索を繰り返します。
-
-### API 名と公定訳が食い違うときは API 名に従います
-
-XKT021 のデータセット名は 地すべり防止**地区** ですが、実体は地すべり等防止法3条の 地すべり防止**区域** で、公定訳は `landslide prevention area` です。メソッド名は `get_landslide_prevention_districts` にしています。
-
-利用者が読むのは MLIT のマニュアルなので、マニュアルの語からメソッドに辿り着ける方を採ります（[命名](#命名)）。**食い違いは docstring に1文で書いてください。** 書かないと、公定訳を知っている利用者が `districts` を訳し間違いと受け取ります。
-
-### 確定
-
-| 日本語 | English | 典拠 |
-|---|---|---|
-| 用途地域 | use district | 建築基準法48条（[/laws/view/4024](https://www.japaneselawtranslation.go.jp/ja/laws/view/4024/je)） |
-| 防火地域 | fire prevention district | 建築基準法53条3項 |
-| 準防火地域 | quasi-fire prevention district | 建築基準法53条3項 |
-| 高度利用地区 | high-level use district | 建築基準法59条 |
-| 高度地区 | height control district | 建築基準法58条 |
-| 都市計画区域 | city planning area | 都市計画法5条（[/laws/view/3841](https://www.japaneselawtranslation.go.jp/ja/laws/view/3841/je)） |
-| 区域区分 | area classification | 都市計画法7条 |
-| 市街化区域 | urbanization promotion area | 都市計画法7条 |
-| 市街化調整区域 | urbanization control area | 都市計画法7条 |
-| 地区計画 | district plan | 都市計画法12条の4 |
-| 地価公示 | land market value publication | MLIT 用語集 200, 201（地価公示室 / 地価公示法） |
-| 地価調査 | land market value research | MLIT 用語集 205（地価調査課） |
-| 都道府県地価調査 | prefectural land market value research | MLIT 用語集 259 |
-| 標準地 | standard site | MLIT 用語集 275 |
-| 基準地 | standard site published by the prefectural government | MLIT 用語集 48 |
-| 土地鑑定委員会 | Land Appraisal Committee | [MLIT 英語ページ](https://www.mlit.go.jp/en/totikensangyo/totikensangyo_fr4_000001.html) |
-| 自然公園 | natural park | 自然公園法2条1号（[laws/view/3060](https://www.japaneselawtranslation.go.jp/ja/laws/view/3060/je)） |
-| 国立公園 | national park | 自然公園法2条2号 |
-| 国定公園 | quasi-national park | 自然公園法2条3号 |
-| 都道府県立自然公園 | prefectural natural park | 自然公園法2条4号 |
-| 特別地域 | special area | 自然公園法20条 |
-| 普通地域 | ordinary area | 自然公園法33条 |
-| 指定緊急避難場所 | designated emergency evacuation site | 災害対策基本法第7章2節、49条の4（[laws/view/4171](https://www.japaneselawtranslation.go.jp/ja/laws/view/4171/je)） |
-| 指定避難所 | designated shelter | 災害対策基本法49条の7 |
-| 災害危険区域 | disaster risk area | 建築基準法39条（[laws/view/4024](https://www.japaneselawtranslation.go.jp/ja/laws/view/4024/je)） |
-| 都市計画施設 | city planning facility | 都市計画法4条6項 |
-| 都市計画事業 | city planning project | 都市計画法4条15項 |
-| 都市施設 | urban facility | 都市計画法4条5項 |
-| 都市計画道路 | city planning road | 都市計画法に定義なし。下記の通り合成 |
-| 人口集中地区 | densely inhabited district | [総務省統計局 英語ページ](https://www.stat.go.jp/english/data/jyutaku/25021.html) |
-| 地すべり防止区域 | landslide prevention area | 都市計画法33条1項8号（[laws/view/3841](https://www.japaneselawtranslation.go.jp/ja/laws/view/3841/je)） |
-| 土砂災害警戒区域 | sediment disaster alert area | 土砂災害防止法の英語題名。都市計画法33条1項8号で引用 |
-| 土砂災害特別警戒区域 | sediment disaster special alert area | 都市計画法33条1項8号 |
-| 急傾斜地崩壊危険区域 | steep slope failure hazard area | 絶滅のおそれのある野生動植物の種の保存に関する法律施行規則5条1項・25条1項・50条2項、鳥獣保護管理法施行規則38条1項 |
-| 液状化 | liquefaction | 津波対策の推進に関する法律10条1項、住宅の品質確保の促進等に関する法律施行規則1条1項、東日本大震災復興特別区域法46条2項 |
-| 盛土 | embankment | 環境影響評価法施行令 別表、航空法施行規則77条1項 |
-| 大規模盛土造成地 | large-scale developed embankment | [土地白書 平成30年度 英語版](https://www.mlit.go.jp/totikensangyo/content/001428844.pdf) p43 |
-| 大規模盛土造成地マップ | map of large-scale developed embankments | 同 p43 |
-| 宅地造成 | residential land development | 宅地造成等規制法の英語題名（建築基準法88条4項が引用）、土地白書英語版 p43 |
-| 宅地の造成 | development of residential land | 土地収用法86条、租税特別措置法62条の3第4項 |
-| 大規模 | large scale | 文脈検索で複数条文 |
-| 国土調査 | National Land Survey | 土地白書英語版 p70 |
-| 地形区分に基づく液状化の発生傾向図 | liquefaction tendency based on topographical classification | [不動産情報ライブラリの地図](https://www.reinfolib.mlit.go.jp/map/)の英語ラベル |
-| 災害履歴 | disaster history | 同 |
-| 砂防法 | Erosion Control Act | 自然環境保全法施行規則19条1項 |
-| 河川法 | River Act | 同条 |
-| 海岸保全区域 | coastal preservation zone | 同条 |
-
-**急傾斜地崩壊危険区域には公定訳が2つあります。** `steep slope failure hazard area` を採ります。2つの省令の4条文で使われていて、もう一方の `steep slope collapse risk area`（自然環境保全法施行規則19条1項）は1条文だけです。[国土交通省の土砂災害の技術資料](https://www.mlit.go.jp/sogoseisaku/inter/keizai/gijyutu/pdf/sediment_e_03.pdf)も `Slope Failure Hazard Areas` を使っています。
-| 立地適正化計画 | location normalization plan | 二次資料のみ。下記の通り |
-| 浸水 | inundation | 津波対策の推進に関する法律6条・8条・10条・16条（[laws/view/4648](https://www.japaneselawtranslation.go.jp/ja/laws/view/4648/je)） |
-| 浸水すると想定される範囲 | the expected ... inundation zone | 同法8条2項 |
-| 想定される | expected | 同法、港湾の施設の技術上の基準を定める省令1条1項5号（[laws/view/3891](https://www.japaneselawtranslation.go.jp/ja/laws/view/3891/je)） |
-| 最大規模 | the maximum scale | 港湾の施設の技術上の基準を定める省令1条1項5号 |
-| 洪水 | flood | 災害対策基本法2条1号 |
-| 高潮 | storm surge | 気象業務法17条・18条・24条、海洋基本法25条2項 |
-| 津波 | tsunami | 津波対策の推進に関する法律 |
-
-**高潮は `storm surge` です。** 建築基準法39条が災害危険区域の指定理由を列挙する文で `high tide` を使っていますが、気象用語としては `storm surge` が標準で、気象業務法と海洋基本法の2法が使っています。国土技術政策総合研究所の英語資料もこのデータセットを `storm surge inundation area` と呼んでいます。
-
-**浸水想定区域そのものの公定訳はありません。** 水防法が法令訳DBに未収録で、`浸水想定区域` も `洪水浸水想定区域` も文脈検索で0件でした。上の部品から[手順2](#優先順位のどこにも訳語がないとき)で合成しています。並びは津波対策法8条2項の `the expected tsunami inundation zone` に従い、`expected` + 災害 + `inundation` + 区域語 の順です。
-
-### 立地適正化計画は二次資料で決めています
-
-[優先順位のどこにも訳語がないとき](#優先順位のどこにも訳語がないとき)の手順3に当たる唯一の語です。`適正化` 単体の訳語典拠がないため、手順2の合成も使えませんでした。
-
-**採った根拠**
-
-- [ジャパンシステムのコラム](https://www.japan-systems.co.jp/column/%E9%83%BD%E5%B8%82%E8%A8%88%E7%94%BB%E3%81%A8%E5%85%AC%E5%85%B1%E6%96%BD%E8%A8%AD%E3%83%9E%E3%83%8D%E3%82%B8%E3%83%A1%E3%83%B3%E3%83%88%E3%82%B3%E3%83%A9%E3%83%A0%E2%91%A1%E3%80%8C%E7%AB%8B%E5%9C%B0/)（2016年、首都大学東京の都市計画研究者）が「国交省資料によると英語では Location Normalization Plan と呼ばれる」と書き、脚注で `Major Efforts Made in the Fields of National Land and Transportation` という MLIT の英語ページを原典に挙げています
-- 査読文献で定着しています。[Sustainability 2020](https://www.mdpi.com/2071-1050/12/3/989/xml)、[Sustainability 2021](https://www.mdpi.com/2071-1050/13/23/13107/xml)（`the Location Normalization Plan (LNP)` と略称まで定義）
-- 競合候補がありません。政府資料にも査読文献にも別の訳は見つかりませんでした
-
-**空振りした当たり先**（原典の MLIT ページには到達できていません）
-
-MLIT 英語トップ（現行と2016年9月3日の Wayback スナップショット）、City Bureau 英語索引 `/en/toshi/index.html`、同索引がリンクする `/common/000996976.pdf`、`/en/toshi/city_plan/compactcity_network.html` と配下の `/en/` PDF（中身は日本語）、英訳パンフ `/common/001048781.pdf`（低炭素まちづくり計画の資料）、Wayback CDX の `mlit.go.jp/en/*effort*`（0件）。
-
-なお City Bureau 英語索引は `Act on Special Measures Concerning Urban Renaissance` と `City Planning Act` を掲げていて、法令訳DBの引用から取った題名と一致します。法令名の方は二重に典拠が付いています。
-
-### 未翻訳の法令の英語題名は、翻訳済みの法令の引用から取れます
-
-法令訳DBに収録されていない法令でも、収録されている法令が条文中で引用していれば公式の英語題名が判明します。**照合には法令番号を使ってください。** 1つの条文が複数の法令を引用していることがあり、条文単位で対応させると別の法令の題名を拾います。
-
-| 法令 | 英語題名 | 引用元 |
-|---|---|---|
-| 水防法（昭和24年法律第193号） | Flood Prevention Act | 災害対策基本法 |
-| 地すべり等防止法（昭和33年法律第30号） | Landslide Prevention Act | 災害対策基本法、都市計画法 |
-| 土砂災害防止法（平成12年法律第57号） | Act for Promotion of Measures to Prevent Sediment Disasters in Sediment Disaster Alert Areas | 都市計画法33条1項8号 |
-| 津波防災地域づくり法（平成23年法律第123号） | Act on Regional Development for Tsunami Disaster Prevention | 建築基準法 |
-| 都市再生特別措置法（平成14年法律第22号） | Act on Special Measures Concerning Urban Renaissance | 都市計画法 |
-| 海岸法 | Coast Act | 災害対策基本法 |
-
-**都市計画法33条1項8号は特に当たり所です。** 開発許可の基準として、災害危険区域・地すべり防止区域・土砂災害特別警戒区域を並べて引用しています。
-
-**都市計画道路は合成した訳語です。** 都市計画法は 都市計画道路 を定義しておらず、都市計画施設として定められた道路の通称です。同法の訳が 都市計画施設 を `city planning facility`、都市計画事業 を `city planning project` としているので、`city planning` + 名詞 は同法自身の造語パターンです。道路 は11条1項1号の都市施設の一覧で `roads` です。12条の11には `roads that are city planning facilities` という言い方も出てきます。
-
-MLIT 用語集は `Land （Market） Value` と括弧付きで記載していますが、識別子に括弧は使えず、[MLIT の英語ページ](https://www.mlit.go.jp/en/totikensangyo/totikensangyo_fr4_000001.html)が括弧なしで運用しているため、括弧を外した形を採用します。
-
-**`public notice` は使いません。** MLIT 用語集 201 に「Public notice という訳もあるようだが、通達と紛らわしい」と、退けた理由が明記されています。英語ページも `Land price public notice system` を「以前の呼称」としています。
-
-**公示と調査は Publication と Research で区別します。** 用語集 259 の 都道府県地価調査 の訳は説明的な文章で、地価公示と同じ "publication" を使っています。そのまま識別子にすると2つのデータセットがほぼ同名になるため、組織名（地価公示室 / 地価調査課）の固有名詞形から採ります。
-
-用途地域の内訳（13種）も同じ典拠から取れます。第一種低層住居専用地域 = category 1 low-rise exclusive residential district、準住居地域 = quasi-residential district、田園住居地域 = countryside residential district、準工業地域 = quasi-industrial district、工業専用地域 = exclusive industrial district、ほか。
-
-### 注意: 用途地域と用途区分は別の語彙です
-
-鑑定評価書API（XCT001）の `division`（`UseDivision`）は**地価公示の用途区分**で、都市計画法の**用途地域**ではありません。
-
-- 準工業**地**（`QUASI_INDUSTRIAL_LAND`）≠ 準工業**地域**（quasi-industrial district）
-- 現況林地、宅地見込地 も用途地域には存在しません
-
-用語集を機械的に当てて `UseDivision` を district に「直す」のは誤りです。
-
-### 不動産情報ライブラリの地図の英語ラベル
-
-[地図](https://www.reinfolib.mlit.go.jp/map/)の英語版に、レイヤーごとの日英対が**73組**入っています。APIを公開しているのと同じシステムなので、データセット名の典拠としては直接的です。
-
-`/map/` の JS チャンクの中にあります。`Liquefaction` などの英語ラベルで全チャンクを grep して、`キー:{header:"ラベル"}` の形を拾うと日本語版と英語版が別オブジェクトで取れます。キーで突き合わせます。
-
-**優先順位は法令の公定訳とMLIT用語集の下です。** ラベルの質が場所によって落ちるためです。実際に確認した問題を挙げます。
-
-- 津波浸水想定 → `Tsunami flooding forecast`。法定の想定であって予報ではありません
-- 大規模盛土造成地マップ → `Large fill site map`。土地白書の `large-scale developed embankment` と、API自身の出力フィールド `embankment_classification` の両方に反します
-- 防火・準防火地域 → `Fire prevention zone`。建築基準法の公定訳は `district` です
-- 洪水浸水想定区域 → `Potential flood inundation area`、高潮浸水想定区域 → `Potential storm surge flood area`。同じ 浸水 が inundation と flood に割れています
-- 地価公示 → `Land price public notices`。MLIT用語集201が「通達と紛らわしい」として却下した語です
-
-**それでも15件のメソッド名を裏付けました。** 特に根拠が弱かった3件が確認できています。立地適正化計画（二次資料のみ）、都市計画道路（合成）、地すべり防止地区（公定訳の `area` に逆らってAPI名の `地区` を採用）。3つ目は「[API 名と公定訳が食い違うときは API 名に従います](#api-名と公定訳が食い違うときは-api-名に従います)」の判断が正しかったことの裏付けです。
-
-**相違があったときは、根拠の強い方を採ります。** こちらが法令やMLIT用語集を典拠にしているならそのまま、こちらが合成や推測で決めていたなら地図のラベルに寄せます。どちらを採ったかと理由を用語集に残してください。
-
-**寄せた2件**は、こちらの名前にどの語の典拠もなかったものです。
-
-| 日本語 | 変更前 | 変更後 |
-|---|---|---|
-| 市区町村役場及び集会施設等 | `..._and_public_meeting_facilities_etc` | `..._and_meeting_facilities_etc` |
-| 将来推計人口250mメッシュ | `get_future_population_estimates_by_250m_mesh` | `get_population_projections_in_250m_grid_squares` |
-
-1件目の `public` は日本語にない語をこちらが足していたもので、訳語の選択ではなく誤りでした。
-
-2件目は地図のラベルを調べ直したところ、3語すべてに作成機関の裏付けがありました。将来推計人口 は[国立社会保障・人口問題研究所](https://www.ipss.go.jp/index-e.asp)が `Population Projections for Japan` として公表しています。`将来` が落ちるのは `projections` が将来を含意するためで、同研究所も落としています。メッシュ は[総務省統計局](https://www.stat.go.jp/english/data/mesh/index.html)が `Grid Square Statistics` を使っています。
-
-**`250m` は `250-meter` にしませんでした。** 地図のラベルは `250-meter` ですが、API名が 250m で、名前はAPI名から導出します。`250-meter` は散文の表記慣習と判断しました。
-
-### 未確定
-
-**現在ありません。** 公開API35本すべての訳語が確定しています。新しいエンドポイントやコード表が増えたとき、典拠を当たっても決まらない語をここに書いてください。
-
-### 収録されていない法令の調べ方
-
-**「法令訳DBに収録なし」は確認済みです。** 法令検索で法令名を引いて0件でした。同じ確認を繰り返さないよう結果を残しています。
-
-収録がなくても、次の2つを先に試してください。それでも出てこなければ優先順位3（所管省庁の英語版資料）に降りることになります。
-
-- [翻訳済みの法令からの引用](#未翻訳の法令の英語題名は翻訳済みの法令の引用から取れます)で英語題名を探す
-- [文脈検索](#文脈検索は-jsonp-を直接叩けます)で語そのものを探す。別の法令が同じ語を使っていることがあります
-
-### 文脈検索は JSONP を直接叩けます
-
-法令検索が法令名で引くのに対し、文脈検索（KWIC）は**訳文の中の語**で引けます。翻訳済み法令を網羅するので、手元にダウンロードしていない法令にも届きます。浸水・高潮・最大規模はこれで見つかりました。
-
-```
-https://www.japaneselawtranslation.go.jp/webkoyori/koyori-json.cgi?q=<語>&callback=cb&title_lang_code=ja&maxshow=30
-```
-
-JSONP なので `cb( ... )` を剥がします。`ret` が `[原文側の行, 訳文側の行]` の2本で、同じ添字が対応します。
-
-**`kwd_lang` は付けないでください。** 付けると 0 件になります。日本語でも英語でも `q` に直接入れれば引けます。
-
-法令訳DBの引き方は、法令名から翻訳IDを引いて `https://www.japaneselawtranslation.go.jp/ja/laws/view/{id}/je` を開きます。対訳ページは日本語と英語の div が交互に並ぶので、定義条（「この法律において『○○』とは」）を見ると定義語の訳が取れます。辞書検索（標準対訳辞書）は一般的な法令用語しか収録しておらず、施設名や区域名は引けません。
-
-XKT004〜018 の施設系（小学校区、学校、保育園・幼稚園等、医療機関、福祉施設、図書館、市区町村役場及び集会施設等）は一般語なので法令典拠は不要です。国土数値情報は英語のデータセット名を公開していないため、当たる先もありません。
-
-### 「等」は `_ETC` にします
-
-`LandTypeCode.PRE_OWNED_CONDOMINIUMS_ETC`（中古マンション等）が先例です。メソッド名でも同じで、保育園・幼稚園**等** → `get_nursery_schools_and_kindergartens_etc`。
+同じコード表や同じ種類の値でも、エンドポイントごとに扱いが違います。**どちらも間違えてもリクエストは飛ばないか、静かに違う結果が返ります。**
 
 ### ズーム範囲は必ずマニュアルの個別ページで確認してください
 
 `/help/apiManual/{endpoint_id}/`（小文字）がサーバ描画されており、`＜パラメータ＞` の表に `z` の行があります。「11（市）～15（詳細）で指定可能」のように書かれています。
 
-**エンドポイントごとに違います。** 実測した範囲は 9-15、11-15、13-15、14-15 の4種類でした。既定の `range(11, 16)` から外れるものは `_get_tile` に `zoom_levels` を渡してください。
+**エンドポイントごとに違います。** 9-15、11-15、13-15、14-15 の4種類があります。既定の `range(11, 16)` から外れるものは `_get_tile` に `zoom_levels` を渡してください。
 
 範囲を間違えても**リクエストは飛びません**。狭すぎればAPIが対応する縮尺を手元で拒否し、広すぎればAPIがエラーを返します。前者はレスポンスに何も現れないので、記載を必ず確認してください。
 
 ### コードの桁数もエンドポイントごとに確認してください
 
-同じコード表でも、桁数の書き方がエンドポイントで違います。都道府県コードは XKT019 が `9`（先頭の0を除く）、XKT021 が `09`（2桁）です。引数名も型も同じなので、コードからは区別が付きません。
+都道府県コードは XKT019 が `9`（先頭の0を除く）、XKT021 と XKT022 が `09`（2桁）です。引数名も型も同じなので、コードからは区別が付きません。
 
 XKT019 側は先頭0付きを `ValueError` で断っています（`_join_unpadded_codes`）。ズーム範囲と同じで、マニュアルが定める形式外の値は手元で断る扱いです。**これをライブラリ全体の規則にしないでください。** XKT021 が求める形式を拒否することになります。
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,222 @@
+# 用語集
+
+メソッド名・引数名・enum 名に使う訳語と、その典拠です。導出の手順は [CONTRIBUTING.md の「命名」](CONTRIBUTING.md#命名)にあります。
+
+**訳語を発明しないでください。** ここにない語は、下記の典拠を当たってから決めてください。
+
+## 典拠の優先順位
+
+1. **[日本法令外国語訳データベースシステム](https://www.japaneselawtranslation.go.jp/)**（法務省）。必要な語の多くは法令用語で、政府公式訳が条文単位で日英対応しています
+2. **[地価に関する国際的な情報発信の強化に向けた検討業務 調査報告書](https://www.mlit.go.jp/common/000214955.pdf)**（国土交通省 土地・建設産業局、平成24年3月）。地価公示・鑑定評価の語彙について MLIT が統一的な英訳を提示する目的で作った用語集です。地価関連語は法令訳DBより詳しく、DBの訳に対する注記もあります
+3. **所管省庁の英語版資料**。法令用語でないもの（統計用語、データセット名）。[土地白書の英語版](https://www.mlit.go.jp/totikensangyo/content/001428844.pdf)は宅地・防災系が載っていて当たり所です
+4. **[不動産情報ライブラリの地図の英語ラベル](#不動産情報ライブラリの地図の英語ラベル)**。データセット名がここで確定することがありますが、質にばらつきがあるので上位3つの下に置きます
+5. **既にこのライブラリで使っている訳語**
+
+## 典拠の調べ方
+
+### 法令訳DB
+
+法令名から翻訳IDを引いて `https://www.japaneselawtranslation.go.jp/ja/laws/view/{id}/je` を開きます。対訳ページは日本語と英語の div が交互に並ぶので、定義条（「この法律において『○○』とは」）を見ると定義語の訳が取れます。
+
+**辞書検索（標準対訳辞書）では引けません。** 一般的な法令用語しか収録しておらず、施設名や区域名は入っていません。
+
+### 未翻訳の法令の英語題名は、翻訳済みの法令の引用から取れます
+
+収録されていない法令でも、収録されている法令が条文中で引用していれば公式の英語題名が判明します。**照合には法令番号を使ってください。** 1つの条文が複数の法令を引用していることがあり、条文単位で対応させると別の法令の題名を拾います。実際に 都市再生特別措置法 を `Urban Railway Promotion Act`（都市鉄道等利便増進法）と誤って拾いました。
+
+| 法令 | 英語題名 | 引用元 |
+|---|---|---|
+| 水防法（昭和24年法律第193号） | Flood Prevention Act | 災害対策基本法 |
+| 地すべり等防止法（昭和33年法律第30号） | Landslide Prevention Act | 災害対策基本法、都市計画法 |
+| 土砂災害防止法（平成12年法律第57号） | Act for Promotion of Measures to Prevent Sediment Disasters in Sediment Disaster Alert Areas | 都市計画法33条1項8号 |
+| 津波防災地域づくり法（平成23年法律第123号） | Act on Regional Development for Tsunami Disaster Prevention | 建築基準法 |
+| 都市再生特別措置法（平成14年法律第22号） | Act on Special Measures Concerning Urban Renaissance | 都市計画法 |
+| 海岸法 | Coast Act | 災害対策基本法 |
+
+**都市計画法33条1項8号は特に当たり所です。** 開発許可の基準として、災害危険区域・地すべり防止区域・土砂災害特別警戒区域を並べて引用しています。
+
+### 文脈検索は JSONP を直接叩けます
+
+法令検索が法令名で引くのに対し、文脈検索（KWIC）は**訳文の中の語**で引けます。翻訳済み法令を網羅するので、手元にダウンロードしていない法令にも届きます。浸水・高潮・最大規模・急傾斜地はこれで見つかりました。
+
+```
+https://www.japaneselawtranslation.go.jp/webkoyori/koyori-json.cgi?q=<語>&callback=cb&title_lang_code=ja&maxshow=30
+```
+
+JSONP なので `cb( ... )` を剥がします。`ret` が `[原文側の行, 訳文側の行]` の2本で、同じ添字が対応します。
+
+**`kwd_lang` は付けないでください。** 付けると 0 件になります。日本語でも英語でも `q` に直接入れれば引けます。
+
+### 施設系は法令典拠が不要です
+
+XKT004〜018 の施設系（小学校区、学校、保育園・幼稚園等、医療機関、福祉施設、図書館、市区町村役場及び集会施設等）は一般語です。国土数値情報は英語のデータセット名を公開していないため、当たる先もありません。
+
+## 優先順位のどこにも訳語がないとき
+
+根拠法が法令訳DBに未収録で、所管省庁の英語資料も旧称のまま揺れている語があります。**どの段階でも訳語を発明しないでください。** 次の順に試します。
+
+1. **その語を名前にしない設計を選ぶ。** コード表なら `str` のままにできます（[enum にするか `str` にするか](CONTRIBUTING.md#enum-にするか-str-にするか)）。メソッド名は避けようがないので、この手は使えません
+2. **典拠のある部品から合成する。** 根拠法自身の造語パターンに従ってください。部品のどちらかに典拠がなければ使えません。[都市計画道路](#都市計画道路は合成した訳語です)と[浸水想定区域](#浸水想定区域そのものの公定訳はありません)がこれです
+3. **二次資料で定着している訳語を採る。** 政府資料が原典として挙げられていて、かつ競合候補がない場合に限ります。[立地適正化計画](#立地適正化計画は二次資料で決めています)だけがこれです
+4. **実装を保留する。** 上のどれも使えないとき
+
+**どの段階で決めたか、そして空振りした当たり先を書いてください。** 原典が後から出てきたときに見直せます。当たり先を書き残さないと、次の人が同じ検索を繰り返します。
+
+**合成（手順2）の前に手順3の当たり先を尽くしてください。** 部品が正しくても構造を間違えられます。大規模盛土造成地 は `造成 = development` を正しく取った上で「地」を主要語と解釈しかけましたが、公定訳は 盛土 を主要語にした `large-scale developed embankment` でした。
+
+## 不動産情報ライブラリの地図の英語ラベル
+
+[地図](https://www.reinfolib.mlit.go.jp/map/)の英語版に、レイヤーごとの日英対が**73組**入っています。APIを公開しているのと同じシステムなので、データセット名の典拠としては直接的です。
+
+`/map/` の JS チャンクの中にあります。`Liquefaction` などの英語ラベルで全チャンクを grep して、`キー:{header:"ラベル"}` の形を拾うと日本語版と英語版が別オブジェクトで取れます。キーで突き合わせます。
+
+**優先順位は法令の公定訳とMLIT用語集の下です。** ラベルの質が場所によって落ちます。
+
+- 津波浸水想定 → `Tsunami flooding forecast`。法定の想定であって予報ではありません
+- 大規模盛土造成地マップ → `Large fill site map`。土地白書の `large-scale developed embankment` と、API自身の出力フィールド `embankment_classification` の両方に反します
+- 防火・準防火地域 → `Fire prevention zone`。建築基準法の公定訳は `district` です
+- 洪水浸水想定区域 → `Potential flood inundation area`、高潮浸水想定区域 → `Potential storm surge flood area`。同じ 浸水 が inundation と flood に割れています
+- 地価公示 → `Land price public notices`。MLIT用語集201が「通達と紛らわしい」として却下した語です
+
+**それでも15件のメソッド名を裏付けました。** 特に根拠が弱かった3件が確認できています。立地適正化計画（二次資料のみ）、都市計画道路（合成）、地すべり防止地区（公定訳の `area` に逆らってAPI名の `地区` を採用）。3つ目は[API 名と公定訳が食い違うときは API 名に従います](CONTRIBUTING.md#api-名と公定訳が食い違うときは-api-名に従います)の裏付けです。
+
+**相違があったときは、根拠の強い方を採ります。** こちらが法令やMLIT用語集を典拠にしているならそのまま、こちらが合成や推測で決めていたなら地図のラベルに寄せます。どちらを採ったかと理由をここに残してください。
+
+寄せたのは2件で、どちらもこちらの名前にどの語の典拠もありませんでした。
+
+| 日本語 | 変更前 | 変更後 |
+|---|---|---|
+| 市区町村役場及び集会施設等 | `..._and_public_meeting_facilities_etc` | `..._and_meeting_facilities_etc` |
+| 将来推計人口250mメッシュ | `get_future_population_estimates_by_250m_mesh` | `get_population_projections_in_250m_grid_squares` |
+
+1件目の `public` は日本語にない語をこちらが足していたもので、訳語の選択ではなく誤りでした。
+
+2件目は調べ直したところ3語すべてに作成機関の裏付けがありました。将来推計人口 は[国立社会保障・人口問題研究所](https://www.ipss.go.jp/index-e.asp)が `Population Projections for Japan` として公表しています。`将来` が落ちるのは `projections` が将来を含意するためで、同研究所も落としています。メッシュ は[総務省統計局](https://www.stat.go.jp/english/data/mesh/index.html)が `Grid Square Statistics` を使っています。
+
+**`250m` は `250-meter` にしませんでした。** 地図のラベルは `250-meter` ですが、API名が 250m で、名前はAPI名から導出します。`250-meter` は散文の表記慣習と判断しました。
+
+## 確定した訳語
+
+| 日本語 | English | 典拠 |
+|---|---|---|
+| 用途地域 | use district | 建築基準法48条（[laws/view/4024](https://www.japaneselawtranslation.go.jp/ja/laws/view/4024/je)）、都市計画法8条3項・9条13項 |
+| 防火地域 | fire prevention district | 建築基準法53条3項 |
+| 準防火地域 | quasi-fire prevention district | 建築基準法53条3項 |
+| 高度利用地区 | high-level use district | 建築基準法59条 |
+| 高度地区 | height control district | 建築基準法58条 |
+| 都市計画区域 | city planning area | 都市計画法5条（[laws/view/3841](https://www.japaneselawtranslation.go.jp/ja/laws/view/3841/je)） |
+| 区域区分 | area classification | 都市計画法7条 |
+| 市街化区域 | urbanization promotion area | 都市計画法7条 |
+| 市街化調整区域 | urbanization control area | 都市計画法7条 |
+| 地区計画 | district plan | 都市計画法12条の4 |
+| 都市計画施設 | city planning facility | 都市計画法4条6項 |
+| 都市計画事業 | city planning project | 都市計画法4条15項 |
+| 都市施設 | urban facility | 都市計画法4条5項 |
+| 都市計画道路 | city planning road | 都市計画法に定義なし。[合成](#都市計画道路は合成した訳語です) |
+| 立地適正化計画 | location normalization plan | [二次資料のみ](#立地適正化計画は二次資料で決めています) |
+| 地価公示 | land market value publication | MLIT 用語集 200, 201（地価公示室 / 地価公示法） |
+| 地価調査 | land market value research | MLIT 用語集 205（地価調査課） |
+| 都道府県地価調査 | prefectural land market value research | MLIT 用語集 259 |
+| 標準地 | standard site | MLIT 用語集 275 |
+| 基準地 | standard site published by the prefectural government | MLIT 用語集 48 |
+| 土地鑑定委員会 | Land Appraisal Committee | [MLIT 英語ページ](https://www.mlit.go.jp/en/totikensangyo/totikensangyo_fr4_000001.html) |
+| 自然公園 | natural park | 自然公園法2条1号（[laws/view/3060](https://www.japaneselawtranslation.go.jp/ja/laws/view/3060/je)） |
+| 国立公園 | national park | 自然公園法2条2号 |
+| 国定公園 | quasi-national park | 自然公園法2条3号 |
+| 都道府県立自然公園 | prefectural natural park | 自然公園法2条4号 |
+| 特別地域 | special area | 自然公園法20条 |
+| 普通地域 | ordinary area | 自然公園法33条 |
+| 指定緊急避難場所 | designated emergency evacuation site | 災害対策基本法第7章2節、49条の4（[laws/view/4171](https://www.japaneselawtranslation.go.jp/ja/laws/view/4171/je)） |
+| 指定避難所 | designated shelter | 災害対策基本法49条の7 |
+| 災害危険区域 | disaster risk area | 建築基準法39条 |
+| 地すべり防止区域 | landslide prevention area | 都市計画法33条1項8号 |
+| 土砂災害警戒区域 | sediment disaster alert area | 土砂災害防止法の英語題名。都市計画法33条1項8号で引用 |
+| 土砂災害特別警戒区域 | sediment disaster special alert area | 都市計画法33条1項8号 |
+| 急傾斜地崩壊危険区域 | steep slope failure hazard area | [公定訳が2つあります](#急傾斜地崩壊危険区域には公定訳が2つあります) |
+| 浸水 | inundation | 津波対策の推進に関する法律6条・8条・10条・16条（[laws/view/4648](https://www.japaneselawtranslation.go.jp/ja/laws/view/4648/je)） |
+| 浸水すると想定される範囲 | the expected ... inundation zone | 同法8条2項 |
+| 想定される | expected | 同法、港湾の施設の技術上の基準を定める省令1条1項5号（[laws/view/3891](https://www.japaneselawtranslation.go.jp/ja/laws/view/3891/je)） |
+| 最大規模 | the maximum scale | 港湾の施設の技術上の基準を定める省令1条1項5号 |
+| 洪水 | flood | 災害対策基本法2条1号 |
+| 高潮 | storm surge | [気象業務法17条・18条・24条、海洋基本法25条2項](#高潮は-storm-surge-です) |
+| 津波 | tsunami | 津波対策の推進に関する法律 |
+| 液状化 | liquefaction | 津波対策の推進に関する法律10条1項、住宅の品質確保の促進等に関する法律施行規則1条1項、東日本大震災復興特別区域法46条2項 |
+| 盛土 | embankment | 環境影響評価法施行令 別表、航空法施行規則77条1項 |
+| 大規模 | large scale | 文脈検索で複数条文 |
+| 大規模盛土造成地 | large-scale developed embankment | [土地白書 平成30年度 英語版](https://www.mlit.go.jp/totikensangyo/content/001428844.pdf) p43 |
+| 大規模盛土造成地マップ | map of large-scale developed embankments | 同 p43 |
+| 宅地造成 | residential land development | 宅地造成等規制法の英語題名（建築基準法88条4項が引用）、土地白書英語版 p43 |
+| 宅地の造成 | development of residential land | 土地収用法86条、租税特別措置法62条の3第4項 |
+| 人口集中地区 | densely inhabited district | [総務省統計局 英語ページ](https://www.stat.go.jp/english/data/jyutaku/25021.html) |
+| 将来推計人口 | population projections | [国立社会保障・人口問題研究所](https://www.ipss.go.jp/index-e.asp) |
+| メッシュ | grid square | [総務省統計局](https://www.stat.go.jp/english/data/mesh/index.html) |
+| 地形区分に基づく液状化の発生傾向図 | liquefaction tendency based on topographical classification | [地図の英語ラベル](#不動産情報ライブラリの地図の英語ラベル) |
+| 災害履歴 | disaster history | 同 |
+| 国土調査 | National Land Survey | 土地白書英語版 p70 |
+| 砂防法 | Erosion Control Act | 自然環境保全法施行規則19条1項 |
+| 河川法 | River Act | 同条 |
+| 海岸保全区域 | coastal preservation zone | 同条 |
+
+用途地域の内訳（13種）も建築基準法から取れます。第一種低層住居専用地域 = category 1 low-rise exclusive residential district、準住居地域 = quasi-residential district、田園住居地域 = countryside residential district、準工業地域 = quasi-industrial district、工業専用地域 = exclusive industrial district、ほか。
+
+## 個別の判断の記録
+
+### 急傾斜地崩壊危険区域には公定訳が2つあります
+
+`steep slope failure hazard area` を採ります。絶滅のおそれのある野生動植物の種の保存に関する法律施行規則5条1項・25条1項・50条2項と鳥獣保護管理法施行規則38条1項の**4条文**で使われています。もう一方の `steep slope collapse risk area`（自然環境保全法施行規則19条1項）は1条文だけです。[国土交通省の土砂災害の技術資料](https://www.mlit.go.jp/sogoseisaku/inter/keizai/gijyutu/pdf/sediment_e_03.pdf)も `Slope Failure Hazard Areas` を使っています。
+
+地図の英語ラベルは `Steep slope collapse risk area` で、少数派の側と一致します。優先順位1の中で条文数の多い方を採る判断を維持しています。
+
+### 高潮は storm surge です
+
+建築基準法39条が災害危険区域の指定理由を列挙する文で `high tide` を使っていますが、気象用語としては `storm surge` が標準で、気象業務法と海洋基本法の2法が使っています。国土技術政策総合研究所の英語資料もこのデータセットを `storm surge inundation area` と呼んでいます。
+
+### 浸水想定区域そのものの公定訳はありません
+
+水防法が法令訳DBに未収録で、`浸水想定区域` も `洪水浸水想定区域` も文脈検索で0件でした。部品から[手順2](#優先順位のどこにも訳語がないとき)で合成しています。並びは津波対策法8条2項の `the expected tsunami inundation zone` に従い、`expected` + 災害 + `inundation` + 区域語 の順です。
+
+XKT026・027・028 の3本で語を揃えています。地図のラベルは `Potential` を使い、しかも 浸水 を inundation と flood に割っているため、一貫性のあるこちらを維持しています。
+
+### 都市計画道路は合成した訳語です
+
+都市計画法は 都市計画道路 を定義しておらず、都市計画施設として定められた道路の通称です。同法の訳が 都市計画施設 を `city planning facility`、都市計画事業 を `city planning project` としているので、`city planning` + 名詞 は同法自身の造語パターンです。道路 は11条1項1号の都市施設の一覧で `roads` です。12条の11には `roads that are city planning facilities` という言い方も出てきます。
+
+地図のラベルも `City planning road` で一致しました。
+
+### 立地適正化計画は二次資料で決めています
+
+[手順3](#優先順位のどこにも訳語がないとき)に当たる唯一の語です。`適正化` 単体の訳語典拠がないため、手順2の合成も使えませんでした。
+
+**採った根拠**
+
+- [ジャパンシステムのコラム](https://www.japan-systems.co.jp/column/%E9%83%BD%E5%B8%82%E8%A8%88%E7%94%BB%E3%81%A8%E5%85%AC%E5%85%B1%E6%96%BD%E8%A8%AD%E3%83%9E%E3%83%8D%E3%82%B8%E3%83%A1%E3%83%B3%E3%83%88%E3%82%B3%E3%83%A9%E3%83%A0%E2%91%A1%E3%80%8C%E7%AB%8B%E5%9C%B0/)（2016年、首都大学東京の都市計画研究者）が「国交省資料によると英語では Location Normalization Plan と呼ばれる」と書き、脚注で `Major Efforts Made in the Fields of National Land and Transportation` という MLIT の英語ページを原典に挙げています
+- 査読文献で定着しています。[Sustainability 2020](https://www.mdpi.com/2071-1050/12/3/989/xml)、[Sustainability 2021](https://www.mdpi.com/2071-1050/13/23/13107/xml)（`the Location Normalization Plan (LNP)` と略称まで定義）
+- 競合候補がありません。政府資料にも査読文献にも別の訳は見つかりませんでした
+- 後から地図のラベルも `Location normalization plan` で一致しました
+
+**空振りした当たり先**（原典の MLIT ページには到達できていません）
+
+MLIT 英語トップ（現行と2016年9月3日の Wayback スナップショット）、City Bureau 英語索引 `/en/toshi/index.html`、同索引がリンクする `/common/000996976.pdf`、`/en/toshi/city_plan/compactcity_network.html` と配下の `/en/` PDF（中身は日本語）、英訳パンフ `/common/001048781.pdf`（低炭素まちづくり計画の資料）、Wayback CDX の `mlit.go.jp/en/*effort*`（0件）。
+
+なお City Bureau 英語索引は `Act on Special Measures Concerning Urban Renaissance` と `City Planning Act` を掲げていて、法令訳DBの引用から取った題名と一致します。法令名の方は二重に典拠が付いています。
+
+### 地価公示と地価調査
+
+**`public notice` は使いません。** MLIT 用語集 201 に「Public notice という訳もあるようだが、通達と紛らわしい」と、退けた理由が明記されています。英語ページも `Land price public notice system` を「以前の呼称」としています。地図のラベルは `Land price public notices` ですが、用語集が明示的に却下した語なので採りません。
+
+**公示と調査は Publication と Research で区別します。** 用語集 259 の 都道府県地価調査 の訳は説明的な文章で、地価公示と同じ `publication` を使っています。そのまま識別子にすると2つのデータセットがほぼ同名になるため、組織名（地価公示室 / 地価調査課）の固有名詞形から採ります。
+
+**括弧は外します。** MLIT 用語集は `Land （Market） Value` と括弧付きで記載していますが、識別子に括弧は使えず、[MLIT の英語ページ](https://www.mlit.go.jp/en/totikensangyo/totikensangyo_fr4_000001.html)が括弧なしで運用しています。
+
+### 用途地域と用途区分は別の語彙です
+
+鑑定評価書API（XCT001）の `division`（`UseDivision`）は**地価公示の用途区分**で、都市計画法の**用途地域**ではありません。
+
+- 準工業**地**（`QUASI_INDUSTRIAL_LAND`）≠ 準工業**地域**（quasi-industrial district）
+- 現況林地、宅地見込地 も用途地域には存在しません
+
+用語集を機械的に当てて `UseDivision` を district に「直す」のは誤りです。
+
+## 未確定
+
+**現在ありません。** 公開API35本すべての訳語が確定しています。新しいエンドポイントやコード表が増えて、典拠を当たっても決まらない語が出たらここに書いてください。


### PR DESCRIPTION
The glossary was 44% of CONTRIBUTING.md and is read differently from the rest: the naming rules are read once to learn how to name something, while the glossary is looked up per term. It also grows with every endpoint, where the rules are stable.

## Changes

- `GLOSSARY.md` holds the source priority, how to search each source, what to do when nothing has the term, the map's label set, the confirmed terms, and the per-term decisions
- `CONTRIBUTING.md` drops from 501 to 305 lines and links to it
- `等` moved to naming, where it belongs
- Zoom ranges and code digit widths moved to a new `API の癖` heading
- Five notes moved off the section about act titles found in citations
- Repaired the confirmed-terms table, which was rendering half its rows as plain text

## Notes

The three sections moved out of the glossary were not glossary at all. Zoom ranges and digit widths now share a heading because they share a failure mode: get either wrong and the request either never leaves or quietly returns something else.

A paragraph about 急傾斜地崩壊危険区域 sat in the middle of the confirmed-terms table, so the eight rows below it rendered as text with pipes instead of a table. The existing table check only looked for blank lines between rows, so it did not catch a paragraph splitting one.

Two pieces of prose were stale: the one saying dead-end searches are recorded pointed at the unconfirmed table, which is now empty, and the derivation examples were introduced as reproducing `the existing 6 methods`, from when there were six rather than thirty-five.

Verified mechanically that no table row was lost across the split. Four headings disappeared, all of them intended: `確定` became `確定した訳語`, `用語集` became the new file's title, `収録されていない法令の調べ方` folded into `典拠の調べ方`, and `注意:` came off the front of the use-district warning.
