### PR TITLE
docs: organise the README around using the API, not around signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 [![License: MIT](https://img.shields.io/pypi/l/pyreinfolib)](https://github.com/matsudan/pyreinfolib/blob/main/LICENSE)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-国土交通省[不動産情報ライブラリ](https://www.reinfolib.mlit.go.jp/)APIサービスのPythonクライアントです。API仕様についての詳細は[API操作説明ページ](https://www.reinfolib.mlit.go.jp/help/apiManual/)をご参照ください。
+国土交通省[不動産情報ライブラリ](https://www.reinfolib.mlit.go.jp/)APIサービスのPythonクライアントです。公開されている35本のAPIすべてに対応しています。
+
+API仕様の詳細は[API操作説明ページ](https://www.reinfolib.mlit.go.jp/help/apiManual/)をご参照ください。APIキーは[利用申請](https://www.reinfolib.mlit.go.jp/help/apiManual/)で取得します。
 
 ## Installation
 
@@ -14,7 +16,7 @@
 pip install pyreinfolib
 ```
 
-## Usage
+## Quick start
 
 ```python
 import os
@@ -22,169 +24,79 @@ import os
 from pyreinfolib import Client
 
 client = Client(api_key=os.environ["REINFOLIB_API_KEY"])
+
+# 2024年第1四半期、渋谷区の不動産取引価格
+result = client.get_real_estate_prices(year=2024, quarter=1, city="13113")
+
+for record in result["data"]:
+    print(record["Type"], record["TradePrice"], record["Area"])
 ```
 
-引数を省略または `None` を渡すと、その絞り込みを行いません。例えば `get_real_estate_prices(year=2024)` は全国のデータが対象になります。
-
-空文字を渡した場合は省略と同じ扱いでなく `ValueError` になります。フォームや環境変数の値をそのまま渡す場合は `city=value or None` としてください。またコードのリストが空（`land_type_code=[]`）の場合も `ValueError` になります。
-
-`Client` はコネクションを再利用します。タイル系APIを複数タイル分呼ぶような使い方では、TLSハンドシェイクが1回で済みます。使い終わったら `close()` するか、`with` を使ってください。
-
-```python
-with Client(api_key=os.environ["REINFOLIB_API_KEY"]) as client:
-    client.get_municipalities(area="13")
-```
-
-### リトライ
-
-スロットリング（HTTP 429）と一時的なサーバエラー（500、502、503、504）は自動で再試行します。APIはリクエスト数の明確な上限を公開しておらず、間隔を空けて実行するよう案内しています。429 は障害ではなく想定される応答です。
-
-待ち時間は指数的に伸びます。既定の `max_retries=3` では 0秒、2秒、4秒の順に待ち、4回目で諦めて `RateLimitError` を送出します。APIが `Retry-After` を返した場合はそちらが優先されます。
-
-```python
-# 再試行しない
-client = Client(api_key=..., max_retries=0)
-```
-
-検索結果0件（HTTP 404）は再試行しません。`timeout` 引数は各試行を制限するもので、再試行の全体を制限するものではありません。
-
-## Example
-
-### 不動産価格（取引価格・成約価格）情報
-
-```python
-from pyreinfolib.enums import PriceClassification
-
-client.get_real_estate_prices(
-    year=2024,
-    quarter=1,
-    price_classification=PriceClassification.REAL_ESTATE_TRANSACTION_PRICE,
-    city="13109",
-)
-```
-
-### 鑑定評価書情報
-
-```python
-from pyreinfolib.enums import UseDivision
-
-client.get_appraisal_reports(year=2024, area="13", division=UseDivision.INDUSTRIAL_LAND)
-```
-
-### 引数がタイル座標のみのAPI
-
-タイル座標のみを取る以下のAPIは、引数が `z`, `x`, `y` だけです。
-
-| メソッド | ID | データ | ズーム |
-|---|---|---|---|
-| `get_city_planning_areas_and_area_classification` | XKT001 | 都市計画区域/区域区分 | 11〜15 |
-| `get_use_districts` | XKT002 | 用途地域 | 11〜15 |
-| `get_location_normalization_plans` | XKT003 | 立地適正化計画 | 11〜15 |
-| `get_schools` | XKT006 | 学校 | 13〜15 |
-| `get_nursery_schools_and_kindergartens_etc` | XKT007 | 保育園・幼稚園等 | 13〜15 |
-| `get_medical_institutions` | XKT010 | 医療機関 | 13〜15 |
-| `get_population_projections_in_250m_grid_squares` | XKT013 | 将来推計人口250mメッシュ | 11〜15 |
-| `get_fire_prevention_districts_and_quasi_fire_prevention_districts` | XKT014 | 防火・準防火地域 | 11〜15 |
-| `get_number_of_passengers_per_station` | XKT015 | 駅別乗降客数 | 11〜15 |
-| `get_municipal_offices_and_meeting_facilities_etc` | XKT018 | 市区町村役場及び集会施設等 | 13〜15 |
-| `get_district_plans` | XKT023 | 地区計画 | 11〜15 |
-| `get_large_scale_developed_embankments` | XKT020 | 大規模盛土造成地マップ | 11〜15 |
-| `get_liquefaction_tendency_based_on_topographical_classification` | XKT025 | 地形区分に基づく液状化の発生傾向図 | 11〜15 |
-| `get_high_level_use_districts` | XKT024 | 高度利用地区 | 11〜15 |
-| `get_expected_flood_inundation_areas_at_maximum_scale` | XKT026 | 洪水浸水想定区域（想定最大規模） | 14〜15 |
-| `get_expected_storm_surge_inundation_areas` | XKT027 | 高潮浸水想定区域 | 13〜15 |
-| `get_expected_tsunami_inundation` | XKT028 | 津波浸水想定 | 14〜15 |
-| `get_sediment_disaster_alert_areas` | XKT029 | 土砂災害警戒区域 | 11〜15 |
-| `get_city_planning_roads` | XKT030 | 都市計画道路 | 11〜15 |
-| `get_designated_emergency_evacuation_sites` | XGT001 | 指定緊急避難場所 | 11〜15 |
+APIの多くは地図のタイル座標を指定して取得します。緯度経度からの変換は `pyreinfolib.tiles` が行います。
 
 ```python
 from pyreinfolib import tiles
 
-client.get_use_districts(*tiles.containing(lon=139.7016, lat=35.6580, z=15))
+tile = tiles.containing(lon=139.7016, lat=35.6580, z=15)
+
+for feature in client.get_use_districts(*tile)["features"]:
+    print(feature["properties"]["use_area_ja"])
 ```
 
-### 行政区域コードでフィルタ可能なAPI
+## Endpoints
 
-以下のAPIはタイル座標に加えて `administrative_area_code`（行政区域コード、5桁）を取ります。**任意**なので、省略すればタイル全体が返ります。
+### 都道府県・市区町村コードで取得するAPI
 
-| メソッド | ID | データ | ズーム |
+| データ | メソッド | ID | 引数 |
 |---|---|---|---|
-| `get_elementary_school_districts` | XKT004 | 小学校区 | 11〜15 |
-| `get_junior_high_school_districts` | XKT005 | 中学校区 | 11〜15 |
-| `get_welfare_facilities` | XKT011 | 福祉施設 | 13〜15 |
-| `get_disaster_risk_areas` | XKT016 | 災害危険区域 | 11〜15 |
-| `get_libraries` | XKT017 | 図書館 | 13〜15 |
-| `get_densely_inhabited_districts` | XKT031 | 人口集中地区 | 9〜15 |
+| 不動産価格（取引価格・成約価格）情報 | `get_real_estate_prices` | XIT001 | `year`、`price_classification`、`quarter`、`area`、`city`、`station`、`language` |
+| 都道府県内市区町村一覧 | `get_municipalities` | XIT002 | `area`、`language` |
+| 鑑定評価書情報 | `get_appraisal_reports` | XCT001 | `year`、`area`、`division` |
 
-`get_disaster_risk_areas` のコードは**代表**行政コードです。複数の市区町村にまたがる区域には、そのうち1つのコードしか付きません。
+### タイル座標で取得するAPI
 
-```python
-client.get_libraries(*tiles.containing(lon=139.7016, lat=35.6580, z=15))
+`z`, `x`, `y` は必須です。それ以外の引数はすべて任意で、省略するとタイル全体が返ります。
 
-# 1つでも、複数でも渡せます
-client.get_elementary_school_districts(z=11, x=1819, y=806, administrative_area_code="13102")
-client.get_elementary_school_districts(z=11, x=1819, y=806, administrative_area_code=["01101", "13102"])
-```
+| データ | メソッド | ID | ズーム | `z`, `x`, `y` に加えて渡せる引数 |
+|---|---|---|---|---|
+| 不動産価格のポイント | `get_real_estate_prices_point` | XPT001 | 11〜15 | `period_from`、`period_to`、`price_classification`、`land_type_code` |
+| 地価公示・地価調査のポイント | `get_land_market_value_publication_and_research_point` | XPT002 | 13〜15 | `year`、`price_classification`、`use_category_code` |
+| 都市計画区域／区域区分 | `get_city_planning_areas_and_area_classification` | XKT001 | 11〜15 | — |
+| 用途地域 | `get_use_districts` | XKT002 | 11〜15 | — |
+| 立地適正化計画 | `get_location_normalization_plans` | XKT003 | 11〜15 | — |
+| 小学校区 | `get_elementary_school_districts` | XKT004 | 11〜15 | `administrative_area_code` |
+| 中学校区 | `get_junior_high_school_districts` | XKT005 | 11〜15 | `administrative_area_code` |
+| 学校 | `get_schools` | XKT006 | 13〜15 | — |
+| 保育園・幼稚園等 | `get_nursery_schools_and_kindergartens_etc` | XKT007 | 13〜15 | — |
+| 医療機関 | `get_medical_institutions` | XKT010 | 13〜15 | — |
+| 福祉施設 | `get_welfare_facilities` | XKT011 | 13〜15 | `administrative_area_code`、`welfare_facility_class_code`、`welfare_facility_middle_class_code`、`welfare_facility_minor_class_code` |
+| 将来推計人口250mメッシュ | `get_population_projections_in_250m_grid_squares` | XKT013 | 11〜15 | — |
+| 防火・準防火地域 | `get_fire_prevention_districts_and_quasi_fire_prevention_districts` | XKT014 | 11〜15 | — |
+| 駅別乗降客数 | `get_number_of_passengers_per_station` | XKT015 | 11〜15 | — |
+| 災害危険区域 | `get_disaster_risk_areas` | XKT016 | 11〜15 | `administrative_area_code` |
+| 図書館 | `get_libraries` | XKT017 | 13〜15 | `administrative_area_code` |
+| 市区町村役場及び集会施設等 | `get_municipal_offices_and_meeting_facilities_etc` | XKT018 | 13〜15 | — |
+| 自然公園地域 | `get_natural_park_areas` | XKT019 | 9〜15 | `prefecture_code`、`district_code` |
+| 大規模盛土造成地マップ | `get_large_scale_developed_embankments` | XKT020 | 11〜15 | — |
+| 地すべり防止地区 | `get_landslide_prevention_districts` | XKT021 | 11〜15 | `prefecture_code`、`administrative_area_code` |
+| 急傾斜地崩壊危険区域 | `get_steep_slope_failure_hazard_areas` | XKT022 | 11〜15 | `prefecture_code`、`administrative_area_code` |
+| 地区計画 | `get_district_plans` | XKT023 | 11〜15 | — |
+| 高度利用地区 | `get_high_level_use_districts` | XKT024 | 11〜15 | — |
+| 地形区分に基づく液状化の発生傾向図 | `get_liquefaction_tendency_based_on_topographical_classification` | XKT025 | 11〜15 | — |
+| 洪水浸水想定区域（想定最大規模） | `get_expected_flood_inundation_areas_at_maximum_scale` | XKT026 | 14〜15 | — |
+| 高潮浸水想定区域 | `get_expected_storm_surge_inundation_areas` | XKT027 | 13〜15 | — |
+| 津波浸水想定 | `get_expected_tsunami_inundation` | XKT028 | 14〜15 | — |
+| 土砂災害警戒区域 | `get_sediment_disaster_alert_areas` | XKT029 | 11〜15 | — |
+| 都市計画道路 | `get_city_planning_roads` | XKT030 | 11〜15 | — |
+| 人口集中地区 | `get_densely_inhabited_districts` | XKT031 | 9〜15 | `administrative_area_code` |
+| 指定緊急避難場所 | `get_designated_emergency_evacuation_sites` | XGT001 | 11〜15 | — |
+| 災害履歴 | `get_disaster_history` | XST001 | 9〜15 | `disastertype_code` |
 
-不動産取引価格情報の `city` と同じ市区町村コードですが、APIが `administrativeAreaCode` と綴っているため引数名も分けています。
+各メソッドの docstring に、引数の形式とコード表へのリンクがあります。
 
-`get_welfare_facilities` は施設種別でも絞り込めます。大分類・中分類・小分類の3階層で、いずれも任意です。
+## Tile coordinates
 
-```python
-client.get_welfare_facilities(
-    z=13,
-    x=7312,
-    y=3008,
-    welfare_facility_class_code=["02", "05"],  # 老人福祉施設、児童福祉施設等
-)
-```
-
-コード表は[大分類](https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMajorClassificationCode.html)、[中分類](https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMiddleClassificationCode.html)、[小分類](https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMinorClassificationCode.html)にあります。enum ではなく `str` です。中分類62件・小分類122件という規模に加えて、大分類7件のうち2件に公表された英訳がないためです（[CONTRIBUTING.md](CONTRIBUTING.md#enum-にするか-str-にするか)）。
-
-### 自然公園地域
-
-`get_natural_park_areas`（XKT019）はズーム9〜15で、都道府県コードと地区コード（振興局区域）で絞り込めます。どちらも任意です。
-
-```python
-client.get_natural_park_areas(z=9, x=227, y=100, prefecture_code=["9", "11"])
-```
-
-**このAPIのコードは先頭の0を付けません。** 栃木県は `"9"` で、`"09"` ではありません。不動産取引価格情報の `area` は `"09"` の形式なので、同じ都道府県コードでも綴りが違います。マニュアルが定めている形式なので、`"09"` を渡すと `ValueError` になります。API に送ると認識されないコードとして空のタイルが返り、自然公園がないタイルと区別が付かなくなるためです。
-
-### 都道府県コードと行政コードでフィルタ可能なAPI
-
-次の2本は都道府県コードと行政コードの両方で絞り込めます。どちらも任意です。
-
-| メソッド | ID | データ | ズーム |
-|---|---|---|---|
-| `get_landslide_prevention_districts` | XKT021 | 地すべり防止地区 | 11〜15 |
-| `get_steep_slope_failure_hazard_areas` | XKT022 | 急傾斜地崩壊危険区域 | 11〜15 |
-
-```python
-client.get_landslide_prevention_districts(z=11, x=1819, y=806, prefecture_code="22")
-client.get_steep_slope_failure_hazard_areas(z=11, x=1819, y=806, administrative_area_code="22100")
-```
-
-**この2本の都道府県コードは先頭の0を付けます。** XKT019 とは逆で、静岡県は `"22"`、栃木県は `"09"` です。引数名も型も同じなので、区別はエンドポイントだけです。マニュアルの記載がそうなっているため、そのまま従っています。
-
-### 災害履歴
-
-`get_disaster_history`（XST001、ズーム9〜15）は災害分類コードで絞り込めます。任意です。
-
-```python
-client.get_disaster_history(z=9, x=227, y=100, disastertype_code=["11", "22"])
-```
-
-指定できるのは 11 浸水域等、12 堤防決壊箇所等、13 高潮浸水域等、14 高潮破堤箇所等、21 がけ崩れ等、22 地すべり等、23 河道閉塞箇所等、24 土石流等、33 液状化、34 地震土砂災害、37 津波高、38 津波浸水域 です。enum ではありません。12件のうち4件（河道閉塞、津波高、浸水域、地震土砂災害）に公表された英訳がないためです（[CONTRIBUTING.md](CONTRIBUTING.md#enum-にするか-str-にするか)）。
-
-**引数名は `disastertype_code` です。** `disaster` の後にアンダースコアが入りません。APIのパラメータ名がそうなっているためです。
-
-## タイル座標
-
-公開APIの多くは XYZ タイル座標で引きます。経度、緯度 (longitude, latitude) から変換するために `pyreinfolib.tiles` を用意しています。
-
-### 点を含むタイル取得 (containing)
+### 点を含むタイルの取得 (containing)
 
 ```python
 from pyreinfolib import tiles
@@ -197,13 +109,11 @@ client.get_number_of_passengers_per_station(*tile)
 
 `Tile` は `z, x, y` の順なので、タイル系メソッドにそのまま展開して渡せます。
 
-受け付けるズームレベルはエンドポイントごとに違います。9〜15、11〜15、13〜15、14〜15 の4種類があり、多くは11〜15です。最も広いのは `get_natural_park_areas` と `get_densely_inhabited_districts` の9〜15、最も狭いのは `get_expected_flood_inundation_areas_at_maximum_scale` と `get_expected_tsunami_inundation` の14〜15です。上の表の「ズーム」列に載せています。
-
-範囲外を渡すと、どのエンドポイントが何を期待しているかを含む `ValueError` になります。`tiles` 側はエンドポイントを知らないのでそこでは検証しません。
-
 引数は名前を付けて渡します（位置引数では渡せません）。緯度と経度はどちらも `float` なので、順序を取り違えても型では気づけないためです。
 
-### 指定範囲を覆うタイル取得 (covering / count_covering)
+受け付けるズームレベルはエンドポイントごとに違います。上の表の「ズーム」列を見てください。範囲外を渡すと、どのエンドポイントが何を期待しているかを含む `ValueError` になります。
+
+### 指定範囲を覆うタイルの取得 (covering / count_covering)
 
 ```python
 box = {"west": 139.665, "south": 35.640, "east": 139.724, "north": 35.679}
@@ -214,12 +124,7 @@ for tile in tiles.covering(**box, z=15):
     client.get_real_estate_prices_point(*tile, period_from=20241, period_to=20242)
 ```
 
-範囲を指定して、それを覆うタイルを取得したいケースです。
-例えばズーム15ではタイル1枚が約1km四方で、渋谷区の範囲を取得したい場合30枚ほどになります。
-
-`covering()` はイテレータを返します。1タイルが1リクエストであり、APIは間隔を空けた呼び出しを求めているため、呼び出し側がペースを制御したり途中で止められる形にしています。
-
-タイル数はズームと範囲で桁が変わります。着手前に `count_covering()` で確認してください。引数は `covering()` と同じです。
+ズーム15ではタイル1枚が約1km四方です。1タイルが1リクエストになるので、着手前に `count_covering()` で枚数を確認してください。引数は `covering()` と同じです。
 
 | 範囲 | z=11 | z=13 | z=15 |
 |---|---|---|---|
@@ -227,7 +132,7 @@ for tile in tiles.covering(**box, z=15):
 | 東京23区 | 9 | 90 | 1155 |
 | 東京都（本土） | 28 | 288 | 4186 |
 
-### タイル範囲取得 (bounds)
+### タイル範囲の取得 (bounds)
 
 ```python
 tiles.bounds(tile)
@@ -235,6 +140,95 @@ tiles.bounds(tile)
 ```
 
 `Bounds` は GeoJSON の bbox と同じ west, south, east, north の順です。
+
+## Filtering
+
+### コードでの絞り込み
+
+コードを取る引数は、1つでもリストでも渡せます。
+
+```python
+client.get_elementary_school_districts(z=11, x=1819, y=806, administrative_area_code="13102")
+client.get_elementary_school_districts(z=11, x=1819, y=806, administrative_area_code=["01101", "13102"])
+```
+
+`price_classification`、`division`、`land_type_code`、`use_category_code` は `pyreinfolib.enums` の enum を渡します。
+
+```python
+from pyreinfolib.enums import LandTypeCode, PriceClassification
+
+client.get_real_estate_prices_point(
+    z=15,
+    x=29099,
+    y=12905,
+    period_from=20241,
+    period_to=20242,
+    price_classification=PriceClassification.CONTRACT_PRICE,
+    land_type_code=[LandTypeCode.LAND, LandTypeCode.LAND_AND_BUILDING],
+)
+```
+
+`price_classification` は API 上どちらも同じ名前ですが、コード体系が2つに分かれています。別の型にしてあるので取り違えは型チェックで検出されます。
+
+| enum | 対象 | コード |
+|---|---|---|
+| `PriceClassification` | 不動産価格（XIT001、XPT001） | `01` 不動産取引価格情報 / `02` 成約価格情報 |
+| `LandPriceClassification` | 地価公示・地価調査（XPT002） | `0` 地価公示 / `1` 都道府県地価調査 |
+
+それ以外のコードは `str` です。福祉施設の3階層（[大分類](https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMajorClassificationCode.html)、[中分類](https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMiddleClassificationCode.html)、[小分類](https://nlftp.mlit.go.jp/ksj/gml/codelist/welfareInstitution_welfareFacilityMinorClassificationCode.html)）と、災害履歴の災害分類コードがこれに当たります。
+
+```python
+client.get_welfare_facilities(
+    z=13,
+    x=7312,
+    y=3008,
+    welfare_facility_class_code=["02", "05"],  # 老人福祉施設、児童福祉施設等
+)
+
+client.get_disaster_history(z=9, x=227, y=100, disastertype_code=["11", "22"])
+```
+
+災害分類コードは 11 浸水域等、12 堤防決壊箇所等、13 高潮浸水域等、14 高潮破堤箇所等、21 がけ崩れ等、22 地すべり等、23 河道閉塞箇所等、24 土石流等、33 液状化、34 地震土砂災害、37 津波高、38 津波浸水域 です。
+
+### 都道府県コードの形式
+
+`prefecture_code` の形式はエンドポイントごとに決まっています。
+
+| メソッド | ID | 形式 | 栃木県の場合 |
+|---|---|---|---|
+| `get_natural_park_areas` | XKT019 | 先頭の0を付けない | `"9"` |
+| `get_landslide_prevention_districts` | XKT021 | 2桁 | `"09"` |
+| `get_steep_slope_failure_hazard_areas` | XKT022 | 2桁 | `"09"` |
+
+引数名も型も同じなので、渡す値からは区別が付きません。XKT019 に `"09"` を渡すと `ValueError` になりますが、**XKT021 と XKT022 に `"9"` を渡した場合は空のタイルが返り**、該当データがないタイルと見分けが付きません。
+
+### 引数の省略
+
+引数を省略するか `None` を渡すと、その絞り込みを行いません。`get_real_estate_prices(year=2024)` は全国が対象になります。
+
+**空文字は省略と同じ扱いになりません。** `ValueError` になります。フォームや環境変数の値をそのまま渡す場合は `city=value or None` としてください。コードのリストが空（`land_type_code=[]`）の場合も `ValueError` です。絞り込んだつもりで全件が返るのを防ぐためです。
+
+## Client configuration
+
+`Client` はコネクションを再利用します。タイル系APIを複数タイル分呼ぶ使い方では、TLSハンドシェイクが1回で済みます。使い終わったら `close()` するか、`with` を使ってください。
+
+```python
+with Client(api_key=os.environ["REINFOLIB_API_KEY"]) as client:
+    client.get_municipalities(area="13")
+```
+
+### リトライ
+
+スロットリング（HTTP 429）と一時的なサーバエラー（500、502、503、504）は自動で再試行します。APIはリクエスト数の上限を公開しておらず、間隔を空けて実行するよう案内しているため、429 は障害ではなく想定される応答です。
+
+待ち時間は指数的に伸びます。既定の `max_retries=3` では 0秒、2秒、4秒の順に待ち、4回目で諦めて `RateLimitError` を送出します。APIが `Retry-After` を返した場合はそちらが優先されます。
+
+```python
+# 再試行しない
+client = Client(api_key=..., max_retries=0)
+```
+
+検索結果0件（HTTP 404）は再試行しません。`timeout` は各試行を制限するもので、再試行の全体を制限するものではありません。
 
 ## Error handling
 
@@ -250,25 +244,22 @@ ReinfolibError
     └── InvalidResponseError レスポンスがJSONではなかった
 ```
 
-### APIのレスポンス結果が0件の場合
+### 結果が0件の場合
 
-タイル座標を取らないAPI（`get_real_estate_prices`、`get_municipalities`、`get_appraisal_reports`）は、条件に合致するデータが無い場合に空の結果ではなく **HTTP 404** を返します（[API操作説明](https://www.reinfolib.mlit.go.jp/help/apiManual/)の3章 Q.8）。このライブラリではこれを `NoResultsError` として送出します。
+都道府県・市区町村コードで取得するAPIは、条件に合致するデータが無い場合に空の結果ではなく **HTTP 404** を返します（[API操作説明](https://www.reinfolib.mlit.go.jp/help/apiManual/)の3章 Q.8）。`NoResultsError` として送出します。
 
 ```python
-from pyreinfolib import Client, NoResultsError
+from pyreinfolib import NoResultsError
 
-client = Client(api_key=...)
 try:
     prices = client.get_real_estate_prices(year=2024, city="13109")
 except NoResultsError:
-    prices = {"data": []}
+    prices = {"status": "OK", "data": []}
 ```
 
-タイル座標を取るAPIは0件でも200と空のフィーチャ一覧を返すため、`NoResultsError` は発生しません。
+タイル座標で取得するAPIは0件でも200と空のフィーチャ一覧を返すため、`NoResultsError` は発生しません。
 
-### APIError の内容を見る
-
-`APIError` とそのサブクラスは、APIが返した本文を保持しています。
+### APIError の中身
 
 ```python
 from pyreinfolib import APIError
@@ -281,21 +272,7 @@ except APIError as e:
 
 ## Typing
 
-型情報を同梱しています（[PEP 561](https://peps.python.org/pep-0561/)）。
-
-`price_classification`、`division`、`land_type_code`、`use_category_code` には `pyreinfolib.enums` の enum メンバーを渡してください。`StrEnum` なので実行時は文字列でも動きますが、型チェックでは拒否されます。単一のコードはリストに包む必要はありません。
-
-`price_classification` は API 上どのエンドポイントでも `priceClassification` という同じ名前ですが、コード体系は2つに分かれています。
-以下のように別の型にしてあるので取り違えは型チェックで検出されます。誤ったコードを送っても API はエラーではなく絞り込まれた結果や空の結果を返すため、実行時には気づきにくい種類の間違いです。
-
-| enum | 対象 | コード |
-|---|---|---|
-| `PriceClassification` | 不動産価格（XIT001、XPT001） | `01` 不動産取引価格情報 / `02` 成約価格情報 |
-| `LandPriceClassification` | 地価公示・地価調査（XPT002） | `0` 地価公示 = `LAND_MARKET_VALUE_PUBLICATION` / `1` 都道府県地価調査 = `PREFECTURAL_LAND_MARKET_VALUE_RESEARCH` |
-
-### レスポンスの型
-
-返り値にも型が付いています。各メソッドのレスポンスの形を `pyreinfolib.types` に `TypedDict` で置いています。
+型情報を同梱しています（[PEP 561](https://peps.python.org/pep-0561/)）。返り値の形は `pyreinfolib.types` に `TypedDict` で置いてあるので、キーの綴り間違いが型エラーになります。
 
 ```python
 prices = client.get_real_estate_prices(year=2024, city="13109")
@@ -322,15 +299,17 @@ districts: UseDistrictsResponse = client.get_use_districts(z=15, x=29099, y=1290
 |---|---|---|
 | `Response` | 返り値そのもの | `UseDistrictsResponse` |
 | `Properties` | タイル系の1フィーチャの `properties` | `UseDistrictsProperties` |
-| `Item` | 非タイル系の `data` の1要素 | `RealEstatePricesItem` |
+| `Item` | 都道府県・市区町村コードで取得するAPIの `data` の1要素 | `RealEstatePricesItem` |
 
-**キーは API のタグ名そのままです。** 各エンドポイントのマニュアル個別ページの `＜出力＞` 表にあるタグ名を、整えずに使っています。国土数値情報の属性コード（`A27_001`）、ローマ字（`kubun_id`）、`_ja` 接尾辞、XCT001 の日本語キー（全角スペース入り）、XPT002 の `proximity_to_transportation_facilitites`（API 側の綴り間違い）も、そのままです。直すと存在しないキーになります。
+### 型を読むときの注意
 
-値の型もマニュアルの宣言通りです。XIT001 は取引価格を含めて全フィールドが文字列型なので、`record["TradePrice"]` は `str` です。同じ `kubun_id` が XKT001 では `int`、XKT023 では `str` なのも、マニュアルの記載がそうなっているためです。
+**キーと値の型は API のマニュアル通りです。** 整えていないので、国土数値情報の属性コード（`A27_001`）、ローマ字（`kubun_id`）、`_ja` 接尾辞、XCT001 の日本語キー（全角スペース入り）、XPT002 の `proximity_to_transportation_facilitites`（API 側の綴り間違い）がそのまま出てきます。
 
-**どのキーが必ず来るかはマニュアルに記載がないため、全フィールドを省略可能として扱っています。** 読み取りは型チェックを通りますが、実行時に `KeyError` の可能性は残ります。null になりうるかも記載がないので表現していません。
+値の型もマニュアルの宣言通りです。XIT001 は取引価格を含めて全フィールドが文字列型なので、`record["TradePrice"]` は `str` です。
 
-`geometry` は6種のジオメトリの合併型で、`type` で絞り込んでから `coordinates` を読みます。XKT029 は同一エンドポイントでポリゴンとラインが混在するとマニュアルが明記しているので、エンドポイントごとに1種類とは決められません。
+**どのキーが必ず来るかはマニュアルに記載がないため、全フィールドを省略可能として扱っています。** 読み取りは型チェックを通りますが、実行時に `KeyError` の可能性は残ります。
+
+`geometry` は6種のジオメトリの合併型です。`type` で絞り込んでから `coordinates` を読みます。
 
 ```python
 for feature in client.get_schools(z=13, x=7269, y=3235)["features"]:
@@ -346,7 +325,7 @@ for feature in client.get_schools(z=13, x=7269, y=3235)["features"]:
 
 ## Contributing
 
-メソッド名や enum メンバー名は、API 操作説明の API 名から機械的に導出しています。導出手順と訳語の用語集は [CONTRIBUTING.md](CONTRIBUTING.md) にあります。
+[CONTRIBUTING.md](CONTRIBUTING.md) に開発環境と命名規則、[GLOSSARY.md](GLOSSARY.md) に訳語と典拠があります。
 
 ## Author
 


### PR DESCRIPTION
The endpoint tables were grouped by which arguments a method takes: one for the twenty that take only tile coordinates, one for the six that also take a municipality code, one for the two that take a prefecture code, and two more for single endpoints. That is a taxonomy of signatures, and it left no place that listed all 35.

## Changes

- Two endpoint tables, split where the calling convention differs: three take a prefecture or municipality code, thirty-two take tile coordinates
- Each row carries the data name, method, endpoint id, zoom range and further arguments
- Quick start with one runnable call, before the index
- Tile coordinates moved above the examples that use them
- Client construction and retries moved below the calls they configure
- A section on the prefecture code formats
- h2 headings in English, section titles nominal rather than verb phrases

## Notes

A reader arrives wanting 用途地域 or hazard data for an address, not wanting an endpoint whose only parameters are z, x and y. Finding 用途地域 previously meant knowing which of five groups it fell into.

Reasons the library is built as it is came out: why a municipality code is `city` on one endpoint and `administrative_area_code` on another, why some code tables are enums and others `str`, why response keys keep the API's spelling mistakes. What a caller has to type stays; why it is spelled that way is in CONTRIBUTING.md and GLOSSARY.md.

One trap earned a place here rather than only in the docstrings. The three endpoints taking a prefecture code disagree on whether it is padded, and passing the unpadded form to the two that want padding returns an empty tile rather than an error. Noticing that means reading two docstrings side by side, which nobody does.

`取得` follows the manual, which names these 取得API.

The 35 table rows were generated from `client.py` and checked against it, since a hand-written index drifts. The old tables had already drifted: XKT020 and XKT024 sat out of id order.
