### PR TITLE
fix!: require a place on the real estate price query

### DIFF
--- a/pyreinfolib/client.py
+++ b/pyreinfolib/client.py
@@ -128,14 +128,15 @@ def _join_unpadded_codes(name: str, codes: Sequence[str] | str | None) -> str | 
 def _compact(params: dict[str, Any]) -> dict[str, Any]:
     """Drop the arguments the caller left out, and refuse the ones left blank.
 
-    `None` is how an argument is omitted, and omitting a filter is a supported request: the
-    only required argument of most endpoints is the period, so leaving `city` out asks for the
-    whole country on purpose.
+    `None` is how an argument is omitted, and omitting a filter is a supported request: most
+    endpoints require nothing beyond a period or a tile, so leaving a filter out widens the
+    query on purpose. Which arguments an endpoint cannot do without is its own method's
+    business; XIT001, for one, needs at least one of `area`, `city` and `station`.
 
-    A blank value is not another way to say that. It used to be dropped as though it were
-    `None`, which meant `city=""` quietly widened a query to the whole country, a blank
-    required argument disappeared from the request altogether, and an empty list of codes read
-    as no filter at all. None of the three announced itself.
+    A blank value is not another way to omit an argument. It used to be dropped as though it
+    were `None`, which meant `city=""` quietly widened a query, a blank required argument
+    disappeared from the request altogether, and an empty list of codes read as no filter at
+    all. None of the three announced itself.
 
     Values are compared against `""` rather than tested for truthiness. `x=0` is a valid tile
     coordinate, and a future parameter whose valid values include `0` would otherwise vanish
@@ -321,7 +322,11 @@ class Client:
         station: str | None = None,
         language: Literal["ja", "en"] | None = None,
     ) -> RealEstatePricesResponse:
-        """Get real estate prices. See https://www.reinfolib.mlit.go.jp/help/apiManual/#titleApi4 for details.
+        """Get real estate prices.
+
+        Takes a place as well as a period: at least one of `area`, `city` and `station` is
+        required. There is no whole-country query.
+        See https://www.reinfolib.mlit.go.jp/help/apiManual/#titleApi4 for details.
         :param price_classification: Price classification.
           If not specified, both real estate transaction prices and contract prices.
         :param year: Transaction period (Year).
@@ -331,7 +336,8 @@ class Client:
         :param station: Station code. See https://nlftp.mlit.go.jp/ksj/gml/datalist/KsjTmplt-N02-v3_1.html
         :param language: `ja` or `en`. If not specified, `ja`.
         :return: Real estate prices.
-        :raises ValueError: If an argument is blank. Leave it out instead, to omit it.
+        :raises ValueError: If `area`, `city` and `station` are all omitted, or an argument is
+          blank. Leave an argument out instead, to omit it.
         :raises NoResultsError: If no transaction matches the given period and area.
         """
         params = _compact(
@@ -345,6 +351,18 @@ class Client:
                 "language": language,
             }
         )
+
+        # Refused on the manual's word, as `z` and a padded code are. Its parameter table marks
+        # all three of these required unless one of the other two is given, and says nothing
+        # about what a query carrying none of them returns.
+        #
+        # After `_compact`, so that `city=""` is reported as the blank it is. A key is present
+        # here only if the caller passed a non-`None` value for it.
+        if not {"area", "city", "station"} & params.keys():
+            raise ValueError(
+                "At least one of `area`, `city` and `station` is required. XIT001 takes no "
+                "query for the whole country, so `year` on its own is not one it documents."
+            )
 
         return self._get("XIT001", params)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -408,22 +408,48 @@ class TestClient:
                 },
             ),
             RequestCase(
-                id="only required param",
-                args={"year": 2025},
-                expected_params={"year": "2025"},
+                # The required minimum is a period and one place. Three cases because any one
+                # of the three places satisfies the requirement on its own.
+                id="year and a prefecture",
+                args={"year": 2025, "area": "13"},
+                expected_params={"year": "2025", "area": "13"},
             ),
             RequestCase(
-                # Omitting the filters is a supported request, not a mistake: `year` is the
-                # only required argument, so this asks for the whole country deliberately.
+                id="year and a municipality",
+                args={"year": 2025, "city": "13109"},
+                expected_params={"year": "2025", "city": "13109"},
+            ),
+            RequestCase(
+                id="year and a station",
+                args={"year": 2025, "station": "003785"},
+                expected_params={"year": "2025", "station": "003785"},
+            ),
+            RequestCase(
+                # Omitting a filter is a supported request, not a mistake, as long as one place
+                # remains: this narrows to a municipality and asks for every quarter of the year.
                 id="omitted optional params are absent from the query",
-                args={"year": 2025, "price_classification": None, "quarter": None, "city": None},
-                expected_params={"year": "2025"},
+                args={"year": 2025, "price_classification": None, "quarter": None, "city": "13109"},
+                expected_params={"year": "2025", "city": "13109"},
             ),
         ],
         ids=lambda case: case.id,
     )
     def test_get_real_estate_prices(self, mock_api, client, case):
         assert_request(mock_api, client.get_real_estate_prices, "XIT001", case)
+
+    def test_get_real_estate_prices_requires_a_place(self, mock_api, client):
+        """`year` on its own reads as a whole-country query, which XIT001 does not offer.
+
+        Nothing is registered on `mock_api`, so a request that went out anyway would fail as an
+        unmatched request rather than spending a round trip to learn the same thing.
+        """
+        with pytest.raises(ValueError) as exc_info:
+            client.get_real_estate_prices(year=2025)
+
+        message = str(exc_info.value)
+        assert "area" in message
+        assert "city" in message
+        assert "station" in message
 
     @pytest.mark.parametrize(
         "case",
@@ -786,16 +812,21 @@ class TestBlankArguments:
     the request, and `land_type_code=[]` read as no filter. None of the three said anything, so
     a caller who thought they had filtered got a wider answer and no indication of it.
 
-    Omitting a filter is still supported and still means the whole country. It is spelled by
-    leaving the argument out, or passing `None`, which `test_get_real_estate_prices` covers.
+    Omitting a filter is still supported and still widens the query. It is spelled by leaving
+    the argument out, or passing `None`, which `test_get_real_estate_prices` covers.
     """
 
     @pytest.mark.parametrize("argument", ["area", "city", "station", "language"])
     def test_a_blank_optional_filter_is_refused(self, mock_api, client, argument):
         """Nothing is registered on `mock_api`, so a blank that slipped through would fail as
-        an unmatched request rather than quietly fetching the whole country.
+        an unmatched request rather than quietly widening the query.
+
+        Matched against the blank message rather than the argument name, because XIT001 also
+        refuses a call that names no place at all, and that refusal names all three places. A
+        blank `area` has to be reported as the blank it is, since the remedy differs: a blank
+        is a value to correct, a missing place is an argument to add.
         """
-        with pytest.raises(ValueError, match=argument):
+        with pytest.raises(ValueError, match=f"Blank value for {argument}"):
             client.get_real_estate_prices(year=2024, **{argument: ""})
 
     @pytest.mark.parametrize(
@@ -814,7 +845,7 @@ class TestBlankArguments:
         request with no query string at all. `get_appraisal_reports` did not go through
         `_compact` and sent `area=` instead. Same argument, same blank, two behaviours.
         """
-        with pytest.raises(ValueError, match="area"):
+        with pytest.raises(ValueError, match="Blank value for area"):
             getattr(client, method_name)(**args)
 
     @pytest.mark.parametrize(

--- a/tests/typing_usage.py
+++ b/tests/typing_usage.py
@@ -36,7 +36,8 @@ def construction() -> None:
 
 
 def non_tile_endpoints(client: Client) -> None:
-    client.get_real_estate_prices(year=2024)
+    # A place as well as a period, XIT001 taking at least one of `area`, `city` and `station`.
+    client.get_real_estate_prices(year=2024, city="13109")
     client.get_real_estate_prices(
         year=2024,
         quarter=1,
@@ -323,11 +324,16 @@ def rejected_by_the_checker(client: Client) -> None:
     )
     client.get_real_estate_prices(
         year=2024,
+        city="13109",
         price_classification=LandPriceClassification.LAND_MARKET_VALUE_PUBLICATION,  # ty: ignore[invalid-argument-type]
     )
 
     # A bare code string is no longer accepted for a parameter that has an enum.
-    client.get_real_estate_prices(year=2024, price_classification="01")  # ty: ignore[invalid-argument-type]
+    client.get_real_estate_prices(
+        year=2024,
+        city="13109",
+        price_classification="01",  # ty: ignore[invalid-argument-type]
+    )
 
     # The point helpers are keyword only, so a longitude and a latitude cannot be swapped by
     # passing them positionally.
@@ -342,7 +348,7 @@ def rejected_by_the_checker(client: Client) -> None:
     # Assigned to `_` rather than passed to `print`. These lines exist only to be type checked,
     # and `_ =` says so; `print` also drew a CodeQL clear-text-logging alert on the fields whose
     # names read as personal data, which several of these types have.
-    record = client.get_real_estate_prices(year=2024)["data"][0]
+    record = client.get_real_estate_prices(year=2024, city="13109")["data"][0]
     _ = record["TradePirce"]  # ty: ignore[invalid-key]
 
     # A key that belongs to a different endpoint. XIT001 spells the municipality code


### PR DESCRIPTION
XIT001's parameter table marks `area`, `city` and `station` as required unless one of
the other two is given, and the manual's own curl example passes `city=13102`.
`get_real_estate_prices(year=2024)` issued the request anyway.

The opposite belief was written down in three places. `_compact`'s docstring said that
leaving `city` out asks for the whole country, the request table carried a `year`-only
case named `only required param`, and `tests/typing_usage.py` showed
`get_real_estate_prices(year=2024)` as the way a caller writes it.

## Changes

- `get_real_estate_prices` raises `ValueError` when `area`, `city` and `station` are all
  omitted
- The check runs after `_compact`, so `city=""` still reports `Blank value for city`
- `_compact`'s docstring no longer claims a period is all any endpoint requires
- `test_get_real_estate_prices` replaces its `year`-only case with three, one per place
- `test_get_real_estate_prices_requires_a_place` added
- The blank argument tests match `Blank value for {argument}` rather than the argument
  name
- `tests/typing_usage.py` passes `city="13109"` on the four `get_real_estate_prices`
  calls that named no place

## Notes

Refused on the manual's word, not on observed behaviour. What the API answers to a query
carrying none of the three has not been checked. This is how `z` and a padded prefecture
code are already handled.

Documenting the requirement without enforcing it was the other option. It leaves
`get_real_estate_prices(year=2024)` spending a round trip to come back as an `APIError`
whose cause is only in the response body.

The check sits in the method rather than in `_compact`. `_compact` is shared by every
endpoint, and this requirement belongs to one of them.

The blank argument tests were narrowed because the new refusal names all three places.
Matching the argument name alone, `test_a_blank_optional_filter_is_refused` would pass
with the blank check removed.

BREAKING CHANGE: `get_real_estate_prices` now requires at least one of `area`, `city` and
`station`. A call that passes only `year` raises `ValueError` instead of issuing a
request. Pass a prefecture code, a municipality code or a station code to say where to
look.
