### PR TITLE
docs: keep the checking record out of the docstrings

### DIFF
--- a/pyreinfolib/client.py
+++ b/pyreinfolib/client.py
@@ -61,10 +61,8 @@ _RETRY_STATUSES = (429, 500, 502, 503, 504)
 # Zoom levels a tile endpoint accepts, as data rather than as a type. Most take this range;
 # each endpoint that does not passes its own to `_get_tile`.
 #
-# A range and not a `Literal`: the levels have to be checkable against a value that arrives
-# computed. `pyreinfolib.tiles` hands back a `Tile` whose `z` is an `int`, and a `Literal`
-# parameter rejects every one of them, which made the documented `client.get_...(*tile)` fail
-# to type check while doing nothing about an out-of-range level held in a variable.
+# A range rather than a `Literal`, because a level has to be checkable against a value that
+# arrives computed: `pyreinfolib.tiles` hands back a `Tile` whose `z` is an `int`.
 _DEFAULT_ZOOM_LEVELS = range(11, 16)
 
 # Statuses whose meaning the API documents. Anything else falls back to `APIError`, which
@@ -133,10 +131,10 @@ def _compact(params: dict[str, Any]) -> dict[str, Any]:
     query on purpose. Which arguments an endpoint cannot do without is its own method's
     business; XIT001, for one, needs at least one of `area`, `city` and `station`.
 
-    A blank value is not another way to omit an argument. It used to be dropped as though it
-    were `None`, which meant `city=""` quietly widened a query, a blank required argument
-    disappeared from the request altogether, and an empty list of codes read as no filter at
-    all. None of the three announced itself.
+    A blank value is not another way to omit an argument, so it is refused rather than dropped.
+    Dropping it would let `city=""` widen a query, take a blank required argument out of the
+    request altogether, and read an empty list of codes as no filter at all. None of the three
+    announces itself.
 
     Values are compared against `""` rather than tested for truthiness. `x=0` is a valid tile
     coordinate, and a future parameter whose valid values include `0` would otherwise vanish
@@ -239,10 +237,9 @@ class Client:
         """
         api_url = urljoin(self.base_url, endpoint)
 
-        # Each failure mode gets its own `try`. Wrapping the whole exchange in one block
-        # would have to re-derive which stage failed from the exception type, which is how
-        # the previous version came to dereference a `response` that connection errors and
-        # timeouts do not have.
+        # Each failure mode gets its own `try`. One block around the whole exchange would
+        # have to re-derive which stage failed from the exception type, and a connection
+        # error or a timeout carries no `response` to read.
         try:
             r = self._session.get(api_url, params=params, timeout=self.timeout)
         except requests.RequestException as e:
@@ -390,7 +387,7 @@ class Client:
         :raises NoResultsError: If no appraisal report matches the given year and area.
         """
         # Through `_compact` although nothing here is optional, so that a blank `area` is
-        # refused rather than sent as `area=`, which is what this method did on its own.
+        # refused rather than sent as `area=`.
         params = _compact({"year": year, "area": area, "division": division})
 
         return self._get("XCT001", params)
@@ -623,12 +620,9 @@ class Client:
     ) -> WelfareFacilitiesResponse:
         """Get welfare facilities (福祉施設).
 
-        The three class codes are one nested classification at three levels of detail, and
-        they are `str` rather than enums. Two of the seven major classes have no published
-        English name -- 身体障害者社会参加支援施設 and 母子・父子福祉施設 rest on the two
-        welfare acts that the Japanese Law Translation database does not carry -- and an enum
-        naming five of seven would leave the caller mixing members with bare strings for the
-        same argument. `area` and `city` are `str` for the same reason.
+        The three class codes are one nested classification at three levels of detail: a minor
+        class code begins with the middle class code it sits under, which begins with the major
+        class code. `020302` is a minor class of `0203`, which is a middle class of `02`.
         See https://www.reinfolib.mlit.go.jp/help/apiManual/xkt011/ for details.
         :param z: Zoom level (scale). 13 ~ 15 (detail)
         :param x: x value of tile coordinates.
@@ -1114,8 +1108,6 @@ class Client:
         Where past disasters are recorded as having struck, compiled by the national land
         survey from historical documents. A feature carries the date and the document it came
         from, so what is here reflects what was recorded rather than everything that happened.
-
-        Singular because 災害履歴 names the record rather than a countable area.
         See https://www.reinfolib.mlit.go.jp/help/apiManual/xst001/ for details.
         :param z: Zoom level (scale). 9 (prefecture) ~ 15 (detail)
         :param x: x value of tile coordinates.
@@ -1125,7 +1117,6 @@ class Client:
           `11` 浸水域等, `12` 堤防決壊箇所等, `13` 高潮浸水域等, `14` 高潮破堤箇所等,
           `21` がけ崩れ等, `22` 地すべり等, `23` 河道閉塞箇所等, `24` 土石流等, `33` 液状化,
           `34` 地震土砂災害, `37` 津波高, `38` 津波浸水域.
-          Not an enum: four of the twelve have no published English name.
           If not specified, every classification.
         :return: Disaster history. (Response format: GeoJson)
         :raises ValueError: If `z` is not between 9 and 15, or `disastertype_code` is empty.

--- a/pyreinfolib/types.py
+++ b/pyreinfolib/types.py
@@ -12,9 +12,8 @@ API's own (`proximity_to_transportation_facilitites` in XPT002). Correcting any 
 a key that no response contains.
 
 **Every record field is optional.** Which keys a response carries is undocumented, and two
-endpoints do omit some. Reading one still type checks, so this costs nothing to use; what it
-avoids is claiming a guarantee the API does not make. Nothing is annotated `| None` either, no
-response having been seen to send one.
+endpoints do omit some. Reading one still type checks, so this costs nothing to use. Nothing is
+annotated `| None` either.
 
 **A field the manual declares 実数型 arrives as `int` when its value is whole**, JSON having one
 number type. It is annotated `float` anyway, which is what arithmetic wants, but it does mean
@@ -65,18 +64,12 @@ class MultiPolygon(TypedDict):
     coordinates: list[list[list[Position]]]
 
 
-# A union rather than one type per endpoint, and reading a live tile from all 32 of them says
-# it cannot be narrowed to one either. The manual's output tables say nothing about geometry.
+# A union rather than one type per endpoint, because a single tile can carry more than one
+# shape: several endpoints mix Polygon with MultiPolygon, and XKT029 answers with Polygon,
+# MultiPolygon and LineString together. The manual's output tables say nothing about geometry.
 #
-# Seven endpoints returned more than one shape in a single tile: XKT001, XKT014, XKT020, XKT026
-# and XKT027 mixed Polygon with MultiPolygon, XKT030 mixed LineString with MultiLineString,
-# XKT029 returned all three of Polygon, MultiPolygon and LineString, and XST001 returned
-# Polygons alongside Points. The shape is not always the one the subject suggests either:
-# XKT015, 駅別乗降客数, answers with LineStrings, because a station is drawn as its platform
-# line rather than as a point.
-#
-# Five of the six members below have been seen. MultiPoint has not, but one tile per endpoint is
-# no basis for dropping a shape GeoJSON allows.
+# The shape is not always the one the subject suggests either. XKT015, 駅別乗降客数, answers
+# with LineStrings, because a station is drawn as its platform line rather than as a point.
 #
 # Narrow on `type` to read `coordinates`; the tag is what makes that possible.
 Geometry = Point | MultiPoint | LineString | MultiLineString | Polygon | MultiPolygon
@@ -86,10 +79,10 @@ class CoordinateReferenceSystem(TypedDict):
     """The `crs` member of a feature collection, in the form GeoJSON used before RFC 7946.
 
     **Worth reading rather than assuming.** The API does not put every endpoint on one datum.
-    Thirty of the 32 tile endpoints name EPSG:6668, which is JGD2011, but XKT017 (図書館) and
-    XKT019 (自然公園地域) name EPSG:4612, which is JGD2000. Coordinates from those two do not
-    line up exactly with the rest, and the gap is widest in Tohoku, where the 2011 earthquake
-    moved the ground between the two realisations.
+    Most name EPSG:6668, which is JGD2011, but XKT017 (図書館) and XKT019 (自然公園地域) name
+    EPSG:4612, which is JGD2000. Coordinates from those two do not line up exactly with the
+    rest, and the gap is widest in Tohoku, where the 2011 earthquake moved the ground between
+    the two realisations.
     """
 
     type: Literal["name"]
@@ -100,9 +93,8 @@ class TileProperties(TypedDict, total=False):
     """Two keys every tile endpoint's `properties` may carry, neither of them documented.
 
     `_id` and `_index` are Elasticsearch document metadata showing through, and they lead the
-    key order. 31 of the 32 tile endpoints send both on every feature; XPT001 sends neither.
-    Optional rather than required for that reason, and because nothing in the manual mentions
-    them at all -- they are not a field a caller should build on.
+    key order. Every tile endpoint sends both except XPT001, which sends neither. Nothing in
+    the manual mentions them, so they are not a field to build on.
     """
 
     _id: str
@@ -115,8 +107,7 @@ P = TypeVar("P")
 class Feature(TypedDict, Generic[P]):
     """One GeoJSON feature. `P` is the endpoint's properties type.
 
-    `geometry` is optional in GeoJSON itself, hence `| None`. No response has been observed
-    using that, but the format allows it and a decoded `None` would otherwise be a lie.
+    `geometry` is `| None` because GeoJSON allows a null geometry.
     """
 
     type: Literal["Feature"]
@@ -131,10 +122,9 @@ class FeatureCollection(TypedDict, Generic[P]):
     this arrives rather than `NoResultsError` whenever a tile holds nothing.
 
     `name` and `crs` are not in the manual and are not required by GeoJSON, hence optional, but
-    all 32 tile endpoints send both. `name` names the source layers, and its type is not
-    consistent: 31 send a string, and XKT001 puts the two layers it merges into one of them as
-    `'urban_plan_area, area_classification'`, while XPT001 alone sends a list. `str | list[str]`
-    covers what arrives rather than what would be tidy.
+    every tile endpoint sends both. `name` names the source layers, and its type is not
+    consistent: most send a string, XKT001 comma joins the two layers it merges into one string
+    as `'urban_plan_area, area_classification'`, and XPT001 sends a list.
 
     `crs` is worth reading; see `CoordinateReferenceSystem` for why.
     """
@@ -151,12 +141,11 @@ T = TypeVar("T")
 class DataResponse(TypedDict, Generic[T]):
     """What the three endpoints that do not take tile coordinates return.
 
-    Unlike everything below, this envelope is not in the manual: its output tables describe
-    one record and stop. The two keys are what the API is observed to send, and what this
-    repository's tests have assumed since before these types existed.
+    Unlike everything below, this envelope is not in the manual: its output tables describe one
+    record and stop. The two keys are what the API sends.
 
-    `status` is not a `Literal["OK"]` because the full set of values it can take is unknown,
-    and an error status never reaches here anyway -- a non-2xx response raises.
+    `status` is a `str` rather than a `Literal["OK"]`, the full set of values it can take being
+    unknown. An error status does not arrive here in any case, a non-2xx response raising.
     """
 
     status: str
@@ -167,12 +156,9 @@ class DataResponse(TypedDict, Generic[T]):
 # are named after the year they hold, and the manual writes that year as a placeholder:
 # `PT01_20XX`, `RTA_20XX`, `HITOKU20XX`.
 #
-# A live tile came back with 339 of them, on years 2020 to 2070 in steps of five. The set is not
-# a clean product of the 34 field prefixes and those 11 years: 2020 carries only `PTN_2020`,
-# `GASSAN` starts at 2055, and `GASSAN2055` through `GASSAN2070` were each missing from some
-# features. Which years appear at all follows whichever projection is published -- the current
-# data is the R6 estimate -- so writing them out would produce a type that goes wrong on the
-# next release, and reading a key that does exist would then be an error. An open mapping is the
+# Which years arrive is not a clean product of the field prefixes and a fixed set of years, and
+# it follows whichever projection is published, so a `TypedDict` would go wrong on the next
+# release and reading a key that does exist would then be an error. An open mapping is the
 # honest type; the feature collection around it is still precise.
 PopulationProjectionsIn250mGridSquaresProperties = dict[str, Any]
 PopulationProjectionsIn250mGridSquaresResponse = FeatureCollection[PopulationProjectionsIn250mGridSquaresProperties]
@@ -240,12 +226,11 @@ MunicipalitiesResponse = DataResponse[MunicipalitiesItem]
 # its fields in Japanese, and all but 13 of them contain a space separating the levels of the
 # source spreadsheet's column headings.
 #
-# These are the keys a live response actually carries, which the manual's output table gets
-# wrong in 63 of 109 places. It renders every separator as U+3000 where the response uses a
-# plain U+0020, and six names differ by more than whitespace: it writes 用途区分コード and
-# 構造コード for what arrive as 用途区分 and 構造, 建蔽率 for 建ぺい率, and 緯度 and 経度 for
-# 位置座標 緯度 and 位置座標 経度. Key order does match, and every declared value type checked
-# out, so the types below still come from the manual.
+# **These are the keys the response carries, not the ones the manual prints.** The manual's
+# output table renders every separator as U+3000 where the response uses a plain U+0020, and six
+# names differ by more than whitespace: it writes 用途区分コード and 構造コード for what arrive as
+# 用途区分 and 構造, 建蔽率 for 建ぺい率, and 緯度 and 経度 for 位置座標 緯度 and 位置座標 経度.
+# A key copied out of the manual will not be found here, or in a response.
 #
 # See https://www.reinfolib.mlit.go.jp/help/apiManual/xct001/
 AppraisalReportsItem = TypedDict(
@@ -446,8 +431,7 @@ class LandMarketValuePublicationAndResearchPointProperties(TileProperties, total
     sewer_supply_availability: bool  # 下水道の有無
     nearest_station_name_ja: str  # 最寄り駅名
     # `facilitites` is the API's spelling, not a typo introduced here: it carries an extra `t`
-    # where the word is `facilities`. Confirmed against a live response, so correcting it would
-    # name a key that does not exist.
+    # where the word is `facilities`.
     proximity_to_transportation_facilitites: int  # 交通施設との近接区分
     u_road_distance_to_nearest_station_name_ja: str  # 最寄り駅までの道路距離
     usage_status_name_ja: str  # 利用現況
@@ -599,16 +583,13 @@ SchoolsResponse = FeatureCollection[SchoolsProperties]
 class NurserySchoolsAndKindergartensEtcProperties(TileProperties, total=False):
     """One feature's `properties` from XKT007, 国土数値情報（保育園・幼稚園等）API.
 
-    The only endpoint whose manual documents two output tables, one for 幼稚園 and こども園 and
-    one for 保育園. The dataset is built by merging 国土数値情報「学校」 and 「福祉施設」, which is
-    where the split comes from.
+    The dataset is built by merging 国土数値情報「学校」 and 「福祉施設」, and the manual documents one
+    output table per side, 幼稚園 and こども園 against 保育園. One type covers both: most keys of
+    both sides arrive on either, blank rather than absent. Only `schoolClassCode`,
+    `schoolClassCode_name_ja` and `closeSchoolCode` are confined to the 幼稚園 side.
 
-    A live response does not come in two shapes, though, which is why this is one type. Every
-    feature in the tile sampled carried `schoolCode` and all three welfare facility codes; the
-    welfare codes simply arrive blank on the 幼稚園 side. Only `schoolClassCode`,
-    `schoolClassCode_name_ja` and `closeSchoolCode` were genuinely conditional, on 8 of 48
-    features. So `welfareFacilityClassCode` being blank or `05` does tell the two apart, but by
-    a value rather than by a key, which a union of `TypedDict`s could not express anyway.
+    **Tell the two apart by a value, not by a key.** `welfareFacilityClassCode` arrives on every
+    feature: `05` on the 保育園 side, blank on the other.
 
     See https://www.reinfolib.mlit.go.jp/help/apiManual/xkt007/
     """
@@ -619,13 +600,15 @@ class NurserySchoolsAndKindergartensEtcProperties(TileProperties, total=False):
     location_ja: str  # 所在地
     administratorCode: int  # 管理者コード
 
-    # 幼稚園 or こども園 only.
+    # From the 学校 side. `schoolCode` arrives on either, blank on the 保育園 side; the other
+    # three are absent there.
     schoolCode: str  # 学校コード
     schoolClassCode: int  # 学校分類コード
     schoolClassCode_name_ja: str  # 学校分類名
     closeSchoolCode: int  # 休校コード
 
-    # 保育園 only. The same three-level classification `get_welfare_facilities` filters on.
+    # From the 福祉施設 side, blank on the 幼稚園 side. The same three-level classification
+    # `get_welfare_facilities` filters on.
     welfareFacilityClassCode: str  # 福祉施設大分類コード
     welfareFacilityMiddleClassCode: str  # 福祉施設中分類コード
     welfareFacilityMinorClassCode: str  # 福祉施設小分類コード


### PR DESCRIPTION
The response types were checked against a live response from all 35 endpoints, and the
record of that check went into the docstrings as well as into CONTRIBUTING.md. Two
sources for one set of facts, and the docstrings are the copy that goes stale: a reader
deciding whether a method returns what they want does not need to know that 63 of
XCT001's 109 keys disagreed with the manual, or that MultiPoint was the one shape never
seen.

## Changes

- `get_welfare_facilities`: the three class codes are documented as one nested
  classification, `020302` under `0203` under `02`, in place of the reason they are `str`
- `get_disaster_history` drops the note on why the codes are not an enum, and the note on
  why the name is singular
- `_DEFAULT_ZOOM_LEVELS` keeps the constraint that a level arrives computed, without the
  account of what a `Literal` did
- `_compact`, `_get` and `get_appraisal_reports` describe what they do rather than what
  they used to do
- `types.py`: the per-endpoint counts come out of `Geometry`, `TileProperties`,
  `FeatureCollection`, `CoordinateReferenceSystem`, `DataResponse`, `AppraisalReportsItem`
  and the population projection mapping
- `NurserySchoolsAndKindergartensEtcProperties`: the field group comments now match the
  response, and the docstring leads with how to tell the two kinds apart

## Notes

XKT007's field groups were labelled `幼稚園 or こども園 only` and `保育園 only`, after the
manual's two output tables. A response does not split that way. `schoolCode` and all three
welfare facility codes arrive on every feature, blank on the side they do not belong to,
and only `schoolClassCode`, `schoolClassCode_name_ja` and `closeSchoolCode` are absent on
the 保育園 side. The labels said otherwise, so they went from a record of the check to a
claim contradicted by it.

`get_welfare_facilities` lost the only statement of how its three codes relate, so the
nesting replaces it. That a minor class code begins with its middle class code, which
begins with its major class code, holds in the manual's own examples and in the response.

CONTRIBUTING.md is unchanged. Everything removed here is already in its table of what
reading every endpoint showed.
