### PR TITLE
fix: validate a covering box at the call

### DIFF
--- a/pyreinfolib/tiles.py
+++ b/pyreinfolib/tiles.py
@@ -64,14 +64,14 @@ def _check_lon(lon: float) -> None:
 
 
 def _check_lat(lat: float) -> None:
-    # Rejecting rather than clamping. A latitude outside this range is either a point Web
-    # Mercator cannot place, or -- far more likely for this API -- a longitude passed as a
-    # latitude, since Japan spans 122E to 154E and every one of those is out of range here.
+    # Rejecting rather than clamping: a value out of range is a mistake to report, not a point
+    # to move to the nearest one that can be placed.
     if not -MAX_LATITUDE <= lat <= MAX_LATITUDE:
         raise ValueError(
             f"`lat` must be between {-MAX_LATITUDE} and {MAX_LATITUDE}, got {lat}. "
-            "Web Mercator cannot represent latitudes beyond that. If this was meant to be a "
-            "longitude, note that `containing` takes keyword arguments."
+            "Web Mercator cannot represent latitudes beyond that. Check whether a longitude "
+            "reached a latitude argument: Japan spans 122E to 154E, and every one of those is "
+            "out of range for a latitude."
         )
 
 
@@ -137,6 +137,12 @@ def _corner_tiles(west: float, south: float, east: float, north: float, z: int) 
     )
 
 
+def _tiles_between(top_left: Tile, bottom_right: Tile) -> Iterator[Tile]:
+    for y in range(top_left.y, bottom_right.y + 1):
+        for x in range(top_left.x, bottom_right.x + 1):
+            yield Tile(top_left.z, x, y)
+
+
 def covering(*, west: float, south: float, east: float, north: float, z: int) -> Iterator[Tile]:
     """Yield every tile that overlaps a bounding box, row by row from the north-west corner.
 
@@ -156,12 +162,16 @@ def covering(*, west: float, south: float, east: float, north: float, z: int) ->
     :param z: Zoom level.
     :return: The covering tiles.
     :raises ValueError: If the box is inverted, or an edge is outside the projected world.
+      Raised by this call, before any tile is yielded, so a `try` around the loop is not where
+      it lands.
     """
+    # Yielding is delegated so that this stays an ordinary function and the box is checked by
+    # the call the caller wrote. A generator body does not run until the first tile is asked
+    # for, which would put the `ValueError` wherever the iteration happens to be -- inside a
+    # worker, or in a loop whose `try` is there for the request rather than for the box.
     top_left, bottom_right = _corner_tiles(west, south, east, north, z)
 
-    for y in range(top_left.y, bottom_right.y + 1):
-        for x in range(top_left.x, bottom_right.x + 1):
-            yield Tile(z, x, y)
+    return _tiles_between(top_left, bottom_right)
 
 
 def count_covering(*, west: float, south: float, east: float, north: float, z: int) -> int:

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -211,12 +211,40 @@ class TestCovering:
 
     @pytest.mark.parametrize("call", [covering, count_covering], ids=["covering", "count_covering"])
     def test_an_inverted_box_is_rejected(self, call):
-        """Silently swapping the edges would hide a caller's mistake behind plausible data."""
+        """Silently swapping the edges would hide a caller's mistake behind plausible data.
+
+        Not wrapped in `list`, so this also pins where `covering` raises. Consuming the result
+        first would let the check sit in a generator body and still pass.
+        """
         with pytest.raises(ValueError, match="west"):
-            list(call(west=139.9, south=35.5, east=139.5, north=35.9, z=13))
+            call(west=139.9, south=35.5, east=139.5, north=35.9, z=13)
 
         with pytest.raises(ValueError, match="south"):
-            list(call(west=139.5, south=35.9, east=139.9, north=35.5, z=13))
+            call(west=139.5, south=35.9, east=139.9, north=35.5, z=13)
+
+    @pytest.mark.parametrize(
+        ("box", "expected"),
+        [
+            ({"west": 139.5, "south": 35.5, "east": 139.9, "north": 86.0}, "lat"),
+            ({"west": 139.5, "south": -86.0, "east": 139.9, "north": 35.9}, "lat"),
+            ({"west": -180.1, "south": 35.5, "east": 139.9, "north": 35.9}, "lon"),
+            ({"west": 139.5, "south": 35.5, "east": 180.1, "north": 35.9}, "lon"),
+        ],
+        ids=["north past the limit", "south past the limit", "west off the world", "east off the world"],
+    )
+    def test_an_edge_outside_the_projected_world_is_rejected_by_the_call(self, box, expected):
+        """These reach `covering` through `containing` rather than through `_corner_tiles`'s own
+        checks, so they need pinning separately from the inverted box.
+        """
+        with pytest.raises(ValueError, match=expected):
+            covering(**box, z=13)
+
+        with pytest.raises(ValueError, match=expected):
+            count_covering(**box, z=13)
+
+    def test_a_negative_zoom_is_rejected_by_the_call(self):
+        with pytest.raises(ValueError, match="z"):
+            covering(west=139.5, south=35.5, east=139.9, north=35.9, z=-1)
 
 
 class TestTile:


### PR DESCRIPTION
`covering` is a generator function, so its body does not run until the first tile is asked
for. The box check sits at the top of that body, which means
`covering(west=140, south=36, east=139, north=35, z=12)` returns an iterator and raises
nothing. `count_covering` takes the same arguments through the same helper and raises on
the spot, and the docstring tells a caller to reach for `count_covering` first, so the two
sit next to each other with different timing.

The checks that arrive through `containing` are late in the same way: a negative `z`, a
longitude past 180, a latitude past the Web Mercator limit. All of them wait for the
iteration.

## Changes

- `covering` is an ordinary function that checks the box and returns `_tiles_between`, a
  new private generator that does the yielding
- `covering`'s `:raises ValueError:` says the call raises, before any tile is yielded
- `test_an_inverted_box_is_rejected` drops the `list()` around the call
- The zoom and edge checks that arrive through `containing` are pinned at the call too
- `_check_lat`'s message drops the pointer to `containing` and asks whether a longitude
  reached a latitude argument

## Notes

The result is still lazy. `_tiles_between` is a generator, so a prefecture at zoom 15 still
yields one tile at a time and `test_it_is_lazy` still holds.

`list()` around the call was what let the old arrangement pass. It was needed to consume
`covering`'s iterator, and `count_covering` never reached it because the `ValueError` came
first, so one parametrised test covered both functions without showing that they raised at
different times. Removing it is the pin.

`_check_lat`'s old message suggested that `containing` takes keyword arguments. It is
reached from `covering` and `count_covering` too, both of which are already keyword only and
name their arguments `west`, `south`, `east` and `north`, so the advice pointed at a function
the caller had not called. It could not help even on the direct path, a swap under
keyword-only arguments being a naming mistake rather than a positional one.

Not marked breaking. A caller who wrapped only the iteration in `try` now sees the
`ValueError` escape, but that timing is not what the docstring described.
