### PR TITLE
docs: cite the tile scheme the manual points at

### DIFF
--- a/pyreinfolib/tiles.py
+++ b/pyreinfolib/tiles.py
@@ -4,10 +4,13 @@ Most of the published API is addressed by tile coordinates rather than by place,
 holding a latitude and longitude cannot reach those endpoints without this conversion. Every
 user of them would otherwise write the same arithmetic.
 
-The grid is the standard slippy map scheme: Web Mercator, with `y` counted from the north
-edge rather than the south. The API manual says only "XYZ" without naming the convention, but
-inverting the tile coordinates it uses in its own examples lands in Japan under this reading
-and in the southern hemisphere under TMS.
+The grid is 地理院タイル's. Every tile endpoint's manual page links 国土地理院's tile coordinate page
+for it, and 国土地理院 defines the scheme as Mercator with everything beyond ±85.0511 degrees
+dropped, so that what is left projects to a square: zoom 0 is that square as a single tile, each
+further level splits every tile into four, and (0, 0) is the north-west corner, with `x` counted
+east and `y` counted south. Counting `y` from the north is what separates the scheme from TMS.
+
+See https://maps.gsi.go.jp/development/siyou.html
 
 Nothing here needs a `Client`, an API key or a network, so these are plain functions.
 
@@ -21,8 +24,9 @@ import math
 from collections.abc import Iterator
 from typing import NamedTuple
 
-# Web Mercator cannot reach the poles: the projection runs to infinity as latitude approaches
-# ±90. This is the conventional cut-off, the latitude at which the projected world is square.
+# The latitude at which the projected world is square, which is where 国土地理院 cuts the grid
+# off. It gives the figure as 約85.0511 度; this is atan(sinh(π)) in degrees, the value in full.
+# Beyond it the projection runs to infinity, so the poles are outside the grid entirely.
 MAX_LATITUDE = 85.0511287798
 
 

--- a/tests/test_tiles.py
+++ b/tests/test_tiles.py
@@ -1,3 +1,4 @@
+import math
 from collections.abc import Iterator
 
 import pytest
@@ -9,9 +10,9 @@ from pyreinfolib.tiles import MAX_LATITUDE, Bounds, Tile, bounds, containing, co
 
 BASE_URL = "https://www.reinfolib.mlit.go.jp/ex-api/external/"
 
-# Tile coordinates lifted from the API manual's own examples, by way of the client tests.
-# These are the only external check available on the grid convention, so they anchor
-# everything else here.
+# Tile coordinates lifted from the API manual's own examples, by way of the client tests. The
+# scheme is 地理院タイル's, which the manual links; these check that the arithmetic here lands
+# where the API's own examples do, so they anchor everything else.
 REFERENCE_TILES = [
     Tile(z=11, x=1819, y=806),
     Tile(z=13, x=7312, y=3008),
@@ -38,8 +39,8 @@ class TestContaining:
     def test_it_reproduces_the_tiles_used_in_the_api_manual(self, tile):
         """Asking for the centre of a known tile must give that tile back.
 
-        This is the check that the grid convention matches the API's, rather than merely
-        being self-consistent.
+        The one check here that reaches outside this library. The round trip below holds for any
+        self-consistent grid, including a wrong one.
         """
         centre = bounds(tile)
         lon = (centre.west + centre.east) / 2
@@ -95,6 +96,12 @@ class TestContaining:
 
 
 class TestContainingRejectsBadInput:
+    def test_the_latitude_limit_is_where_the_projected_world_is_square(self):
+        """国土地理院 gives the cut-off as 約85.0511 度, and rounding to that would move the edge of
+        the grid. The value in full is the latitude whose Mercator y is half the world's width.
+        """
+        assert MAX_LATITUDE == pytest.approx(math.degrees(math.atan(math.sinh(math.pi))))
+
     @pytest.mark.parametrize("lat", [90.0, 86.0, -86.0, -90.0], ids=str)
     def test_latitudes_web_mercator_cannot_place(self, lat):
         with pytest.raises(ValueError, match="lat"):


### PR DESCRIPTION
`pyreinfolib.tiles` said that the API manual names no tile convention, and settled the
question by inverting the coordinates in the manual's own examples: they land in Japan under
XYZ and in the southern hemisphere under TMS. The manual does name it. All 32 tile endpoint
pages link 国土地理院's tile coordinate page, and the 地理院タイル spec behind it defines the
scheme outright, `y` counted south included.

## Changes

- `tiles`'s module docstring states the scheme as 国土地理院 defines it and links
  https://maps.gsi.go.jp/development/siyou.html, in place of the inference from the manual's
  example coordinates
- `MAX_LATITUDE`'s comment carries the same source, and how the constant relates to the
  約85.0511 度 that 国土地理院 prints
- `REFERENCE_TILES`'s comment and `test_it_reproduces_the_tiles_used_in_the_api_manual` no
  longer call those coordinates the only external check on the grid convention
- `test_the_latitude_limit_is_where_the_projected_world_is_square` added

## Notes

The reference tiles keep their place. They no longer stand alone behind the convention, but
they are still the only check that this library's arithmetic agrees with coordinates the API
itself uses, which a citation cannot establish.

国土地理院 prints 約85.0511 度, so the docstring now quotes a figure a later edit could round the
constant down to. `MAX_LATITUDE` holds ten digits of atan(sinh(π)), and rounding it moves the
edge of the grid, hence the test.
